### PR TITLE
fix: remove VARCHAR(255) restrictions from all denormalized tables

### DIFF
--- a/api/src/main/resources/marquez/db/migration/V106__remove_varchar255_from_denormalized_tables.sql
+++ b/api/src/main/resources/marquez/db/migration/V106__remove_varchar255_from_denormalized_tables.sql
@@ -1,0 +1,34 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- V106: Remove VARCHAR(255) length restrictions from dataset/job denormalized tables
+-- and fix remaining columns on run lineage tables missed by V88
+
+-- run_lineage_denormalized: location, parent_job_name, source_name were missed by V88
+ALTER TABLE run_lineage_denormalized
+  ALTER COLUMN location TYPE VARCHAR,
+  ALTER COLUMN parent_job_name TYPE VARCHAR,
+  ALTER COLUMN source_name TYPE VARCHAR;
+
+-- run_parent_lineage_denormalized: same columns missed by V88
+ALTER TABLE run_parent_lineage_denormalized
+  ALTER COLUMN location TYPE VARCHAR,
+  ALTER COLUMN parent_job_name TYPE VARCHAR,
+  ALTER COLUMN source_name TYPE VARCHAR;
+
+-- dataset_denormalized
+ALTER TABLE dataset_denormalized
+  ALTER COLUMN name TYPE VARCHAR,
+  ALTER COLUMN physical_name TYPE VARCHAR,
+  ALTER COLUMN schema_location TYPE VARCHAR,
+  ALTER COLUMN namespace_name TYPE VARCHAR,
+  ALTER COLUMN source_name TYPE VARCHAR;
+
+-- dataset_version_denormalized
+ALTER TABLE dataset_version_denormalized
+  ALTER COLUMN schema_location TYPE VARCHAR;
+
+-- job_denormalized
+ALTER TABLE job_denormalized
+  ALTER COLUMN name TYPE VARCHAR,
+  ALTER COLUMN namespace_name TYPE VARCHAR,
+  ALTER COLUMN simple_name TYPE VARCHAR,
+  ALTER COLUMN parent_job_name TYPE VARCHAR;

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -25,7 +25,7 @@ extras_require["dev"] = set(sum(extras_require.values(), []))
 
 setup(
     name="swar00pduthks_marquez_python",
-    version="0.52.58",
+    version="0.52.59",
     description="Marquez Python Client",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@
 7|   --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
 8|   --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 9|
-10| version=0.52.58
+10| version=0.52.59
 11|


### PR DESCRIPTION
## Summary
- Adds migration V106 to widen 15 columns across 4 denorm tables from `VARCHAR(255)` to unbounded `VARCHAR`
- Fixes columns on `run_lineage_denormalized` and `run_parent_lineage_denormalized` (`location`, `parent_job_name`, `source_name`) that were missed by V88
- Fixes all restricted columns on `dataset_denormalized`, `dataset_version_denormalized`, and `job_denormalized` which were never addressed
- Bumps version to 0.52.59

## Test plan
- [ ] Run Flyway migrations against a local DB and verify all columns accept values longer than 255 chars
- [ ] Verify existing data is unaffected after migration