### PR TITLE
Feature/mesh lineage perf design

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
   unit-test-client-python:
     working_directory: ~/marquez/clients/python
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.9
     steps:
       - *checkout_project_root
       - run: pip install -e .[dev]
@@ -129,7 +129,7 @@ jobs:
   build-client-python:
     working_directory: ~/marquez/clients/python
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.9
     steps:
       - *checkout_project_root
       - run: python setup.py sdist bdist_wheel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,6 @@ only-on-release: &only-on-release
     branches:
       ignore: /.*/
 
-orbs:
-  codecov: codecov/codecov@3.2.3
-
 jobs:
   build-api:
     working_directory: ~/marquez
@@ -35,7 +32,6 @@ jobs:
       - run: ./gradlew --no-daemon --stacktrace api:javadoc
       - run: ./gradlew --no-daemon --stacktrace api:build
       - run: ./gradlew --no-daemon api:jacocoTestReport
-      - codecov/upload
       - store_test_results:
           path: api/build/test-results/test
       - store_artifacts:
@@ -104,7 +100,6 @@ jobs:
       - run: ./gradlew --no-daemon --stacktrace clients:java:javadoc
       - run: ./gradlew --no-daemon --stacktrace clients:java:build
       - run: ./gradlew --no-daemon clients:java:jacocoTestReport
-      - codecov/upload
       - store_test_results:
           path: clients/java/build/test-results/test
       - store_artifacts:
@@ -124,7 +119,6 @@ jobs:
       - run: pip install -e .[dev]
       - run: flake8
       - run: pytest --cov=marquez_python tests/
-      - codecov/upload
 
   build-client-python:
     working_directory: ~/marquez/clients/python

--- a/.circleci/get-jdk17.sh
+++ b/.circleci/get-jdk17.sh
@@ -7,9 +7,19 @@
 
 set -e
 
-wget -qO - https://adoptium.jfrog.io/adoptium/api/gpg/key/public | sudo apt-key add -
-sudo add-apt-repository --yes https://adoptium.jfrog.io/adoptium/deb
-sudo apt-get update --allow-releaseinfo-change && sudo apt-get install --yes temurin-17-jdk
+# If JDK 17 is already present on the machine image, skip download.
+if java -version 2>&1 | grep -q 'version "17'; then
+  echo "JDK 17 already available"
+  java -version
+  echo "DONE!"
+  exit 0
+fi
+
+# Adoptium Temurin 17 (adoptium.jfrog.io was retired in 2024; use packages.adoptium.net)
+wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add -
+echo "deb https://packages.adoptium.net/artifactory/deb $(lsb_release -cs) main" \
+  | sudo tee /etc/apt/sources.list.d/adoptium.list
+sudo apt-get update && sudo apt-get install --yes temurin-17-jdk
 sudo update-alternatives --set java /usr/lib/jvm/temurin-17-jdk-amd64/bin/java
 sudo update-alternatives --set javac /usr/lib/jvm/temurin-17-jdk-amd64/bin/javac
 java -version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,19 @@ $ ./gradlew :api:testIntegration  # run only integration tests
 $ ./gradlew :api:testDataAccess   # run only data access tests
 ```
 
+By default the `api` integration tests spin up a PostgreSQL container via [Testcontainers](https://testcontainers.com/), which requires a running Docker daemon. In environments without Docker, point the tests at an already-running PostgreSQL by setting `MARQUEZ_TEST_PG_HOST` (this is off by default, so CI is unaffected):
+
+```bash
+$ export MARQUEZ_TEST_PG_HOST=localhost   # enables external-DB mode (skips Testcontainers)
+$ export MARQUEZ_TEST_PG_PORT=5432        # optional, default 5432
+$ export MARQUEZ_TEST_PG_DB=marquez_test  # optional, default marquez_test — a THROWAWAY db (Flyway cleans it)
+$ export MARQUEZ_TEST_PG_USER=postgres    # optional, default postgres
+$ export MARQUEZ_TEST_PG_PASSWORD=        # optional, default empty
+$ ./gradlew :api:test --tests marquez.db.OpenLineageDaoTest
+```
+
+The target database is dropped/re-migrated by Flyway on each test class, so always use a dedicated throwaway database.
+
 We use [spotless](https://github.com/diffplug/spotless) to format our code. This ensures `.java` files are formatted to comply with [Google Java Style](https://google.github.io/styleguide/javaguide.html). Make sure your code is formatted before pushing any changes, otherwise CI will fail:
 
 ```

--- a/api/load-testing/get-lineage-load-test.js
+++ b/api/load-testing/get-lineage-load-test.js
@@ -131,9 +131,10 @@ export default function (data) {
       'response time < 10s': (r) => r.timings.duration < 10000,
     });
 
-    if (!success) {
-      errorRate.add(1);
-    }
+    // Record every request so 'errors' is the true failure fraction. Adding only
+    // on failure makes the Rate 1/1=100% on the first slow request (a single CI
+    // outlier), which trips the rate<0.05 threshold spuriously.
+    errorRate.add(!success);
 
     responseTimeWithFacets.add(response.timings.duration);
     responseSizeWithFacets.add(response.body.length);
@@ -157,9 +158,8 @@ export default function (data) {
       'response time < 10s': (r) => r.timings.duration < 10000,
     });
 
-    if (!success) {
-      errorRate.add(1);
-    }
+    // Record every request so 'errors' is the true failure fraction (see above).
+    errorRate.add(!success);
 
     responseTimeWithoutFacets.add(response.timings.duration);
     responseSizeWithoutFacets.add(response.body.length);
@@ -199,8 +199,8 @@ function textSummary(data, options) {
   if (data.metrics.response_time_without_facets?.values?.avg !== undefined) {
     summary += `${indent}Without Facets:\n`;
     summary += `${indent}  Response Time (avg): ${data.metrics.response_time_without_facets.values.avg.toFixed(2)}ms\n`;
-    summary += `${indent}  Response Time (p95): ${data.metrics.response_time_without_facets.values['p(95)'].toFixed(2)}ms\n`;
-    summary += `${indent}  Response Time (p99): ${data.metrics.response_time_without_facets.values['p(99)'].toFixed(2)}ms\n`;
+    summary += `${indent}  Response Time (p95): ${(data.metrics.response_time_without_facets.values['p(95)'] ?? 0).toFixed(2)}ms\n`;
+    summary += `${indent}  Response Time (p99): ${(data.metrics.response_time_without_facets.values['p(99)'] ?? 0).toFixed(2)}ms\n`;
     summary += `${indent}  Response Size (avg): ${(data.metrics.response_size_without_facets.values.avg / 1024).toFixed(2)}KB\n\n`;
   }
 
@@ -208,8 +208,8 @@ function textSummary(data, options) {
   if (data.metrics.response_time_with_facets?.values?.avg !== undefined) {
     summary += `${indent}With Facets:\n`;
     summary += `${indent}  Response Time (avg): ${data.metrics.response_time_with_facets.values.avg.toFixed(2)}ms\n`;
-    summary += `${indent}  Response Time (p95): ${data.metrics.response_time_with_facets.values['p(95)'].toFixed(2)}ms\n`;
-    summary += `${indent}  Response Time (p99): ${data.metrics.response_time_with_facets.values['p(99)'].toFixed(2)}ms\n`;
+    summary += `${indent}  Response Time (p95): ${(data.metrics.response_time_with_facets.values['p(95)'] ?? 0).toFixed(2)}ms\n`;
+    summary += `${indent}  Response Time (p99): ${(data.metrics.response_time_with_facets.values['p(99)'] ?? 0).toFixed(2)}ms\n`;
     summary += `${indent}  Response Size (avg): ${(data.metrics.response_size_with_facets.values.avg / 1024).toFixed(2)}KB\n\n`;
   }
 

--- a/api/src/main/java/marquez/MarquezApp.java
+++ b/api/src/main/java/marquez/MarquezApp.java
@@ -43,6 +43,7 @@ import marquez.jobs.PartitionManagementJob;
 import marquez.jobs.backfill.DatasetFacetsPartitionBackfillJob;
 import marquez.jobs.backfill.DenormV1BackfillJob;
 import marquez.jobs.backfill.GraphV1BackfillJob;
+import marquez.jobs.backfill.LineageEventsPartitionBackfillJob;
 import marquez.jobs.backfill.RunFacetsPartitionBackfillJob;
 import marquez.logging.DelegatingSqlLogger;
 import marquez.logging.LabelledSqlLogger;
@@ -236,7 +237,9 @@ public final class MarquezApp extends Application<MarquezConfig> {
                 : java.util.List.of());
     for (String v :
         java.util.List.of(
-            RunFacetsPartitionBackfillJob.VERSION, DatasetFacetsPartitionBackfillJob.VERSION)) {
+            RunFacetsPartitionBackfillJob.VERSION,
+            DatasetFacetsPartitionBackfillJob.VERSION,
+            LineageEventsPartitionBackfillJob.VERSION)) {
       if (!enabledVersions.contains(v)) {
         enabledVersions.add(v);
       }
@@ -249,6 +252,7 @@ public final class MarquezApp extends Application<MarquezConfig> {
     backfillOrchestrator.register(new DenormV1BackfillJob(jdbi, backfillConfig));
     backfillOrchestrator.register(new RunFacetsPartitionBackfillJob(jdbi, backfillConfig));
     backfillOrchestrator.register(new DatasetFacetsPartitionBackfillJob(jdbi, backfillConfig));
+    backfillOrchestrator.register(new LineageEventsPartitionBackfillJob(jdbi, backfillConfig));
 
     // Register V3 Graph API Resources conditionally to prevent crashing standard V1 databases
     final AtomicBoolean ageEnabled = new AtomicBoolean(false);

--- a/api/src/main/java/marquez/MarquezApp.java
+++ b/api/src/main/java/marquez/MarquezApp.java
@@ -40,6 +40,7 @@ import marquez.jobs.BackfillOrchestrator;
 import marquez.jobs.DbRetentionJob;
 import marquez.jobs.MaterializeViewRefresherJob;
 import marquez.jobs.PartitionManagementJob;
+import marquez.jobs.backfill.DatasetFacetsPartitionBackfillJob;
 import marquez.jobs.backfill.DenormV1BackfillJob;
 import marquez.jobs.backfill.GraphV1BackfillJob;
 import marquez.jobs.backfill.RunFacetsPartitionBackfillJob;
@@ -233,8 +234,12 @@ public final class MarquezApp extends Application<MarquezConfig> {
             backfillConfig.getEnabledVersions() != null
                 ? backfillConfig.getEnabledVersions()
                 : java.util.List.of());
-    if (!enabledVersions.contains(RunFacetsPartitionBackfillJob.VERSION)) {
-      enabledVersions.add(RunFacetsPartitionBackfillJob.VERSION);
+    for (String v :
+        java.util.List.of(
+            RunFacetsPartitionBackfillJob.VERSION, DatasetFacetsPartitionBackfillJob.VERSION)) {
+      if (!enabledVersions.contains(v)) {
+        enabledVersions.add(v);
+      }
     }
     backfillConfig.setEnabledVersions(enabledVersions);
 
@@ -243,6 +248,7 @@ public final class MarquezApp extends Application<MarquezConfig> {
     // Relational jobs need only the DB — register regardless of AGE availability.
     backfillOrchestrator.register(new DenormV1BackfillJob(jdbi, backfillConfig));
     backfillOrchestrator.register(new RunFacetsPartitionBackfillJob(jdbi, backfillConfig));
+    backfillOrchestrator.register(new DatasetFacetsPartitionBackfillJob(jdbi, backfillConfig));
 
     // Register V3 Graph API Resources conditionally to prevent crashing standard V1 databases
     final AtomicBoolean ageEnabled = new AtomicBoolean(false);

--- a/api/src/main/java/marquez/MarquezApp.java
+++ b/api/src/main/java/marquez/MarquezApp.java
@@ -42,6 +42,7 @@ import marquez.jobs.MaterializeViewRefresherJob;
 import marquez.jobs.PartitionManagementJob;
 import marquez.jobs.backfill.DenormV1BackfillJob;
 import marquez.jobs.backfill.GraphV1BackfillJob;
+import marquez.jobs.backfill.RunFacetsPartitionBackfillJob;
 import marquez.logging.DelegatingSqlLogger;
 import marquez.logging.LabelledSqlLogger;
 import marquez.logging.LoggingMdcFilter;
@@ -219,19 +220,29 @@ public final class MarquezApp extends Application<MarquezConfig> {
 
     final Jdbi jdbi = context.getJdbi();
 
-    // Build orchestrator early so both AGE-dependent and relational backfill jobs can register
-    BackfillConfig backfillConfig = config.getBackfill();
-    final BackfillOrchestrator backfillOrchestrator =
-        (backfillConfig != null
-                && backfillConfig.getEnabledVersions() != null
-                && !backfillConfig.getEnabledVersions().isEmpty())
-            ? new BackfillOrchestrator(backfillConfig)
-            : null;
+    // Build orchestrator early so both AGE-dependent and relational backfill jobs can register.
+    BackfillConfig backfillConfig =
+        config.getBackfill() != null ? config.getBackfill() : BackfillConfig.builder().build();
 
-    // DENORM_V1 only needs the relational DB — register it regardless of AGE availability
-    if (backfillOrchestrator != null) {
-      backfillOrchestrator.register(new DenormV1BackfillJob(jdbi, backfillConfig));
+    // The run_facets online partitioning cutover (RUN_FACETS_PARTITION_V1) must always complete,
+    // regardless of which other backfills an operator enabled — otherwise a large table armed by
+    // V108 would never finish its copy + swap. Inject it into the enabled set if absent; on
+    // small/empty installs V108 already swapped inline and the job no-ops immediately.
+    java.util.List<String> enabledVersions =
+        new java.util.ArrayList<>(
+            backfillConfig.getEnabledVersions() != null
+                ? backfillConfig.getEnabledVersions()
+                : java.util.List.of());
+    if (!enabledVersions.contains(RunFacetsPartitionBackfillJob.VERSION)) {
+      enabledVersions.add(RunFacetsPartitionBackfillJob.VERSION);
     }
+    backfillConfig.setEnabledVersions(enabledVersions);
+
+    final BackfillOrchestrator backfillOrchestrator = new BackfillOrchestrator(backfillConfig);
+
+    // Relational jobs need only the DB — register regardless of AGE availability.
+    backfillOrchestrator.register(new DenormV1BackfillJob(jdbi, backfillConfig));
+    backfillOrchestrator.register(new RunFacetsPartitionBackfillJob(jdbi, backfillConfig));
 
     // Register V3 Graph API Resources conditionally to prevent crashing standard V1 databases
     final AtomicBoolean ageEnabled = new AtomicBoolean(false);

--- a/api/src/main/java/marquez/MarquezContext.java
+++ b/api/src/main/java/marquez/MarquezContext.java
@@ -164,7 +164,12 @@ public final class MarquezContext {
     this.tagService = new TagService(baseDao);
     this.tagService.init(tags);
     this.openLineageService = new OpenLineageService(baseDao, runService);
-    this.lineageService = new LineageService(lineageDao, jobDao, runDao);
+    this.lineageService =
+        new LineageService(
+            lineageDao,
+            jobDao,
+            runDao,
+            Boolean.parseBoolean(System.getenv("MARQUEZ_LINEAGE_USE_EDGE_BFS")));
     this.columnLineageService = new ColumnLineageService(columnLineageDao, datasetFieldDao);
     this.searchService = new SearchService(searchConfig);
     this.statsService = new StatsService(statsDao);

--- a/api/src/main/java/marquez/db/DatasetFacetsDao.java
+++ b/api/src/main/java/marquez/db/DatasetFacetsDao.java
@@ -92,7 +92,8 @@ public interface DatasetFacetsDao {
              lineage_event_type,
              type,
              name,
-             facet
+             facet,
+             namespace
           ) VALUES (
              :createdAt,
              :datasetUuid,
@@ -102,7 +103,8 @@ public interface DatasetFacetsDao {
              :lineageEventType,
              :type,
              :name,
-             :facet
+             :facet,
+             (SELECT namespace_name FROM runs WHERE uuid = :runUuid)
           )
       """)
   void insertDatasetFacet(

--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -449,15 +449,24 @@ public interface LineageDao {
         l.job_name,
         COALESCE(l.input_uuids, Array[]::uuid[]) AS input_uuids,
         COALESCE(l.output_uuids, Array[]::uuid[]) AS output_uuids,
-        JSON_AGG(DISTINCT jsonb_build_object('namespace', l.input_dataset_namespace,
-                    'name', l.input_dataset_name,
-                    'version', l.input_dataset_version,
-                    'dataset_version_uuid', l.input_dataset_version_uuid)) FILTER (WHERE l.input_dataset_name IS NOT NULL) AS input_versions,
-        JSON_AGG(DISTINCT jsonb_build_object('namespace', l.output_dataset_namespace,
-                                                            'name', l.output_dataset_name,
-                                                            'version', l.output_dataset_version,
-                                                            'dataset_version_uuid', l.output_dataset_version_uuid
-                                                            )) FILTER (WHERE l.output_dataset_name IS NOT NULL) AS output_versions,
+        (SELECT JSON_AGG(obj) FROM (
+            SELECT DISTINCT ON (input_dataset_version_uuid)
+                jsonb_build_object('namespace', input_dataset_namespace,
+                                   'name', input_dataset_name,
+                                   'version', input_dataset_version,
+                                   'dataset_version_uuid', input_dataset_version_uuid) AS obj
+            FROM lineage_graph sub WHERE sub.run_uuid = l.run_uuid AND input_dataset_name IS NOT NULL
+            ORDER BY input_dataset_version_uuid
+        ) dedup_in) AS input_versions,
+        (SELECT JSON_AGG(obj) FROM (
+            SELECT DISTINCT ON (output_dataset_version_uuid)
+                jsonb_build_object('namespace', output_dataset_namespace,
+                                   'name', output_dataset_name,
+                                   'version', output_dataset_version,
+                                   'dataset_version_uuid', output_dataset_version_uuid) AS obj
+            FROM lineage_graph sub WHERE sub.run_uuid = l.run_uuid AND output_dataset_name IS NOT NULL
+            ORDER BY output_dataset_version_uuid
+        ) dedup_out) AS output_versions,
         COALESCE(Array_AGG(distinct l.uuid) FILTER (WHERE l.uuid IS NOT NULL), Array[]::uuid[]) as child_run_id,
         COALESCE(Array_AGG(distinct l.parent_run_uuid) FILTER (WHERE l.parent_run_uuid IS NOT NULL), Array[]::uuid[]) as parent_run_id,
         JSON_AGG(DISTINCT jsonb_build_object(rf.name, rf.facet)) FILTER (WHERE rf.name IS NOT NULL) as facets,

--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -295,7 +295,9 @@ public interface LineageDao {
 
           UNION ALL
 
-          -- upstream: this run consumed a dataset version produced by lineage node
+          -- A recursive CTE allows only ONE recursive term, so both traversal
+          -- directions (this run consumed a version produced upstream, or produced a
+          -- version consumed downstream) must share a single self-referential arm.
           SELECT
             io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
             io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
@@ -306,27 +308,9 @@ public interface LineageDao {
             io.input_uuids, io.output_uuids,
             l.depth + 1 AS depth
           FROM run_lineage_denormalized io
-          JOIN lineage l ON io.input_version_uuid = l.output_version_uuid
-            AND io.run_uuid != l.run_uuid
-          WHERE l.depth < :depth
-            AND (:minDate::date IS NULL OR io.run_date >= :minDate::date)
-            AND (:maxDate::date IS NULL OR io.run_date <= :maxDate::date)
-
-          UNION ALL
-
-          -- downstream: this run produced a dataset version consumed by lineage node
-          SELECT
-            io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
-            io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
-            io.input_dataset_uuid, io.output_version_uuid, io.output_dataset_uuid,
-            io.input_dataset_namespace, io.input_dataset_name, io.input_dataset_version,
-            io.input_dataset_version_uuid, io.output_dataset_namespace, io.output_dataset_name,
-            io.output_dataset_version, io.output_dataset_version_uuid, io.uuid, io.parent_run_uuid,
-            io.input_uuids, io.output_uuids,
-            l.depth + 1 AS depth
-          FROM run_lineage_denormalized io
-          JOIN lineage l ON io.output_version_uuid = l.input_version_uuid
-            AND io.run_uuid != l.run_uuid
+          JOIN lineage l
+            ON (io.input_version_uuid = l.output_version_uuid OR io.output_version_uuid = l.input_version_uuid)
+           AND io.run_uuid != l.run_uuid
           WHERE l.depth < :depth
             AND (:minDate::date IS NULL OR io.run_date >= :minDate::date)
             AND (:maxDate::date IS NULL OR io.run_date <= :maxDate::date)
@@ -397,7 +381,8 @@ public interface LineageDao {
 
           UNION ALL
 
-          -- upstream arm
+          -- A recursive CTE allows only ONE recursive term, so both traversal
+          -- directions share a single self-referential arm.
           SELECT
             io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
             io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
@@ -408,27 +393,9 @@ public interface LineageDao {
             io.input_uuids, io.output_uuids,
             l.depth + 1 AS depth
           FROM run_lineage_denormalized io
-          JOIN lineage_graph l ON io.input_version_uuid = l.output_version_uuid
-            AND io.run_uuid != l.run_uuid
-          WHERE l.depth < :depth
-            AND (:minDate::date IS NULL OR io.run_date >= :minDate::date)
-            AND (:maxDate::date IS NULL OR io.run_date <= :maxDate::date)
-
-          UNION ALL
-
-          -- downstream arm
-          SELECT
-            io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
-            io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
-            io.input_dataset_uuid, io.output_version_uuid, io.output_dataset_uuid,
-            io.input_dataset_namespace, io.input_dataset_name, io.input_dataset_version,
-            io.input_dataset_version_uuid, io.output_dataset_namespace, io.output_dataset_name,
-            io.output_dataset_version, io.output_dataset_version_uuid, io.uuid, io.parent_run_uuid,
-            io.input_uuids, io.output_uuids,
-            l.depth + 1 AS depth
-          FROM run_lineage_denormalized io
-          JOIN lineage_graph l ON io.output_version_uuid = l.input_version_uuid
-            AND io.run_uuid != l.run_uuid
+          JOIN lineage_graph l
+            ON (io.input_version_uuid = l.output_version_uuid OR io.output_version_uuid = l.input_version_uuid)
+           AND io.run_uuid != l.run_uuid
           WHERE l.depth < :depth
             AND (:minDate::date IS NULL OR io.run_date >= :minDate::date)
             AND (:maxDate::date IS NULL OR io.run_date <= :maxDate::date)
@@ -542,7 +509,8 @@ public interface LineageDao {
 
              UNION ALL
 
-             -- upstream arm
+             -- A recursive CTE allows only ONE recursive term, so both traversal
+             -- directions share a single self-referential arm.
              SELECT
                io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
                io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
@@ -553,27 +521,9 @@ public interface LineageDao {
                io.input_uuids, io.output_uuids,
                l.depth + 1 AS depth
              FROM run_parent_lineage_denormalized io
-             JOIN lineage l ON io.input_version_uuid = l.output_version_uuid
-               AND io.run_uuid != l.run_uuid
-             WHERE l.depth < :depth
-               AND (:minDate::date IS NULL OR io.run_date >= :minDate::date)
-               AND (:maxDate::date IS NULL OR io.run_date <= :maxDate::date)
-
-             UNION ALL
-
-             -- downstream arm
-             SELECT
-               io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
-               io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
-               io.input_dataset_uuid, io.output_version_uuid, io.output_dataset_uuid,
-               io.input_dataset_namespace, io.input_dataset_name, io.input_dataset_version,
-               io.input_dataset_version_uuid, io.output_dataset_namespace, io.output_dataset_name,
-               io.output_dataset_version, io.output_dataset_version_uuid, io.uuid, io.parent_run_uuid,
-               io.input_uuids, io.output_uuids,
-               l.depth + 1 AS depth
-             FROM run_parent_lineage_denormalized io
-             JOIN lineage l ON io.output_version_uuid = l.input_version_uuid
-               AND io.run_uuid != l.run_uuid
+             JOIN lineage l
+               ON (io.input_version_uuid = l.output_version_uuid OR io.output_version_uuid = l.input_version_uuid)
+              AND io.run_uuid != l.run_uuid
              WHERE l.depth < :depth
                AND (:minDate::date IS NULL OR io.run_date >= :minDate::date)
                AND (:maxDate::date IS NULL OR io.run_date <= :maxDate::date)
@@ -640,7 +590,8 @@ public interface LineageDao {
 
           UNION ALL
 
-          -- upstream arm
+          -- A recursive CTE allows only ONE recursive term, so both traversal
+          -- directions share a single self-referential arm.
           SELECT
             io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
             io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
@@ -651,27 +602,9 @@ public interface LineageDao {
             io.input_uuids, io.output_uuids,
             l.depth + 1 AS depth
           FROM run_parent_lineage_denormalized io
-          JOIN lineage_graph l ON io.input_version_uuid = l.output_version_uuid
-            AND io.run_uuid != l.run_uuid
-          WHERE l.depth < :depth
-            AND (:minDate::date IS NULL OR io.run_date >= :minDate::date)
-            AND (:maxDate::date IS NULL OR io.run_date <= :maxDate::date)
-
-          UNION ALL
-
-          -- downstream arm
-          SELECT
-            io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
-            io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
-            io.input_dataset_uuid, io.output_version_uuid, io.output_dataset_uuid,
-            io.input_dataset_namespace, io.input_dataset_name, io.input_dataset_version,
-            io.input_dataset_version_uuid, io.output_dataset_namespace, io.output_dataset_name,
-            io.output_dataset_version, io.output_dataset_version_uuid, io.uuid, io.parent_run_uuid,
-            io.input_uuids, io.output_uuids,
-            l.depth + 1 AS depth
-          FROM run_parent_lineage_denormalized io
-          JOIN lineage_graph l ON io.output_version_uuid = l.input_version_uuid
-            AND io.run_uuid != l.run_uuid
+          JOIN lineage_graph l
+            ON (io.input_version_uuid = l.output_version_uuid OR io.output_version_uuid = l.input_version_uuid)
+           AND io.run_uuid != l.run_uuid
           WHERE l.depth < :depth
             AND (:minDate::date IS NULL OR io.run_date >= :minDate::date)
             AND (:maxDate::date IS NULL OR io.run_date <= :maxDate::date)

--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -418,6 +418,10 @@ public interface LineageDao {
       FROM lineage_nodes l
       LEFT JOIN run_facets rf ON rf.run_uuid = l.run_uuid
         AND rf.name IN (<includeFacets>)
+        -- prune the run_facets RANGE(lineage_event_time) partitions to the seed
+        -- runs' window (run_facets is partitioned in V108)
+        AND (:minDate::date IS NULL OR rf.lineage_event_time >= :minDate::date)
+        AND (:maxDate::date IS NULL OR rf.lineage_event_time < (:maxDate::date + 1))
       GROUP BY
         l.run_uuid, l.created_at, l.updated_at, l.started_at, l.ended_at,
         l.state, l.job_uuid, l.job_version_uuid, l.namespace_name, l.job_name, l.input_uuids, l.output_uuids
@@ -611,6 +615,9 @@ public interface LineageDao {
       FROM lineage_graph l
       LEFT JOIN run_facets rf ON (rf.run_uuid = l.uuid OR rf.run_uuid = l.run_uuid)
         AND rf.name IN (<includeFacets>)
+        -- prune the run_facets RANGE(lineage_event_time) partitions (V108)
+        AND (:minDate::date IS NULL OR rf.lineage_event_time >= :minDate::date)
+        AND (:maxDate::date IS NULL OR rf.lineage_event_time < (:maxDate::date + 1))
       GROUP BY
         COALESCE(l.run_uuid, l.uuid), l.created_at, l.updated_at, l.started_at, l.ended_at,
         l.state, l.job_uuid, l.job_version_uuid, l.namespace_name, l.job_name, l.input_uuids, l.output_uuids

--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -295,6 +295,7 @@ public interface LineageDao {
 
           UNION ALL
 
+          -- upstream: this run consumed a dataset version produced by lineage node
           SELECT
             io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
             io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
@@ -305,9 +306,27 @@ public interface LineageDao {
             io.input_uuids, io.output_uuids,
             l.depth + 1 AS depth
           FROM run_lineage_denormalized io
-          JOIN lineage l
-            ON (io.input_version_uuid = l.output_version_uuid OR io.output_version_uuid = l.input_version_uuid)
-           AND io.run_uuid != l.run_uuid
+          JOIN lineage l ON io.input_version_uuid = l.output_version_uuid
+            AND io.run_uuid != l.run_uuid
+          WHERE l.depth < :depth
+            AND (:minDate::date IS NULL OR io.run_date >= :minDate::date)
+            AND (:maxDate::date IS NULL OR io.run_date <= :maxDate::date)
+
+          UNION ALL
+
+          -- downstream: this run produced a dataset version consumed by lineage node
+          SELECT
+            io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
+            io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
+            io.input_dataset_uuid, io.output_version_uuid, io.output_dataset_uuid,
+            io.input_dataset_namespace, io.input_dataset_name, io.input_dataset_version,
+            io.input_dataset_version_uuid, io.output_dataset_namespace, io.output_dataset_name,
+            io.output_dataset_version, io.output_dataset_version_uuid, io.uuid, io.parent_run_uuid,
+            io.input_uuids, io.output_uuids,
+            l.depth + 1 AS depth
+          FROM run_lineage_denormalized io
+          JOIN lineage l ON io.output_version_uuid = l.input_version_uuid
+            AND io.run_uuid != l.run_uuid
           WHERE l.depth < :depth
             AND (:minDate::date IS NULL OR io.run_date >= :minDate::date)
             AND (:maxDate::date IS NULL OR io.run_date <= :maxDate::date)
@@ -325,15 +344,24 @@ public interface LineageDao {
         job_name,
         COALESCE(input_uuids, Array[]::uuid[]) AS input_uuids,
         COALESCE(output_uuids, Array[]::uuid[]) AS output_uuids,
-        JSON_AGG(DISTINCT jsonb_build_object('namespace', input_dataset_namespace,
-                    'name', input_dataset_name,
-                    'version', input_dataset_version,
-                    'dataset_version_uuid', input_dataset_version_uuid)) FILTER (WHERE input_dataset_name IS NOT NULL) AS input_versions,
-        JSON_AGG(DISTINCT jsonb_build_object('namespace', output_dataset_namespace,
-                                                            'name', output_dataset_name,
-                                                            'version', output_dataset_version,
-                                                            'dataset_version_uuid', output_dataset_version_uuid
-                                                            )) FILTER (WHERE output_dataset_name IS NOT NULL) AS output_versions,
+        (SELECT JSON_AGG(obj) FROM (
+            SELECT DISTINCT ON (input_dataset_version_uuid)
+                jsonb_build_object('namespace', input_dataset_namespace,
+                                   'name', input_dataset_name,
+                                   'version', input_dataset_version,
+                                   'dataset_version_uuid', input_dataset_version_uuid) AS obj
+            FROM lineage sub WHERE sub.run_uuid = lineage.run_uuid AND input_dataset_name IS NOT NULL
+            ORDER BY input_dataset_version_uuid
+        ) dedup_in) AS input_versions,
+        (SELECT JSON_AGG(obj) FROM (
+            SELECT DISTINCT ON (output_dataset_version_uuid)
+                jsonb_build_object('namespace', output_dataset_namespace,
+                                   'name', output_dataset_name,
+                                   'version', output_dataset_version,
+                                   'dataset_version_uuid', output_dataset_version_uuid) AS obj
+            FROM lineage sub WHERE sub.run_uuid = lineage.run_uuid AND output_dataset_name IS NOT NULL
+            ORDER BY output_dataset_version_uuid
+        ) dedup_out) AS output_versions,
         COALESCE(Array_AGG(distinct uuid) FILTER (WHERE uuid IS NOT NULL), Array[]::uuid[]) as child_run_id,
         COALESCE(Array_AGG(distinct parent_run_uuid) FILTER (WHERE parent_run_uuid IS NOT NULL), Array[]::uuid[]) as parent_run_id,
         MIN(depth) AS depth
@@ -369,6 +397,7 @@ public interface LineageDao {
 
           UNION ALL
 
+          -- upstream arm
           SELECT
             io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
             io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
@@ -379,9 +408,27 @@ public interface LineageDao {
             io.input_uuids, io.output_uuids,
             l.depth + 1 AS depth
           FROM run_lineage_denormalized io
-          JOIN lineage_graph l
-            ON (io.input_version_uuid = l.output_version_uuid OR io.output_version_uuid = l.input_version_uuid)
-           AND io.run_uuid != l.run_uuid
+          JOIN lineage_graph l ON io.input_version_uuid = l.output_version_uuid
+            AND io.run_uuid != l.run_uuid
+          WHERE l.depth < :depth
+            AND (:minDate::date IS NULL OR io.run_date >= :minDate::date)
+            AND (:maxDate::date IS NULL OR io.run_date <= :maxDate::date)
+
+          UNION ALL
+
+          -- downstream arm
+          SELECT
+            io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
+            io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
+            io.input_dataset_uuid, io.output_version_uuid, io.output_dataset_uuid,
+            io.input_dataset_namespace, io.input_dataset_name, io.input_dataset_version,
+            io.input_dataset_version_uuid, io.output_dataset_namespace, io.output_dataset_name,
+            io.output_dataset_version, io.output_dataset_version_uuid, io.uuid, io.parent_run_uuid,
+            io.input_uuids, io.output_uuids,
+            l.depth + 1 AS depth
+          FROM run_lineage_denormalized io
+          JOIN lineage_graph l ON io.output_version_uuid = l.input_version_uuid
+            AND io.run_uuid != l.run_uuid
           WHERE l.depth < :depth
             AND (:minDate::date IS NULL OR io.run_date >= :minDate::date)
             AND (:maxDate::date IS NULL OR io.run_date <= :maxDate::date)
@@ -486,6 +533,7 @@ public interface LineageDao {
 
              UNION ALL
 
+             -- upstream arm
              SELECT
                io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
                io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
@@ -496,9 +544,27 @@ public interface LineageDao {
                io.input_uuids, io.output_uuids,
                l.depth + 1 AS depth
              FROM run_parent_lineage_denormalized io
-             JOIN lineage l
-               ON (io.input_version_uuid = l.output_version_uuid OR io.output_version_uuid = l.input_version_uuid)
-              AND io.run_uuid != l.run_uuid
+             JOIN lineage l ON io.input_version_uuid = l.output_version_uuid
+               AND io.run_uuid != l.run_uuid
+             WHERE l.depth < :depth
+               AND (:minDate::date IS NULL OR io.run_date >= :minDate::date)
+               AND (:maxDate::date IS NULL OR io.run_date <= :maxDate::date)
+
+             UNION ALL
+
+             -- downstream arm
+             SELECT
+               io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
+               io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
+               io.input_dataset_uuid, io.output_version_uuid, io.output_dataset_uuid,
+               io.input_dataset_namespace, io.input_dataset_name, io.input_dataset_version,
+               io.input_dataset_version_uuid, io.output_dataset_namespace, io.output_dataset_name,
+               io.output_dataset_version, io.output_dataset_version_uuid, io.uuid, io.parent_run_uuid,
+               io.input_uuids, io.output_uuids,
+               l.depth + 1 AS depth
+             FROM run_parent_lineage_denormalized io
+             JOIN lineage l ON io.output_version_uuid = l.input_version_uuid
+               AND io.run_uuid != l.run_uuid
              WHERE l.depth < :depth
                AND (:minDate::date IS NULL OR io.run_date >= :minDate::date)
                AND (:maxDate::date IS NULL OR io.run_date <= :maxDate::date)
@@ -565,6 +631,7 @@ public interface LineageDao {
 
           UNION ALL
 
+          -- upstream arm
           SELECT
             io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
             io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
@@ -575,9 +642,27 @@ public interface LineageDao {
             io.input_uuids, io.output_uuids,
             l.depth + 1 AS depth
           FROM run_parent_lineage_denormalized io
-          JOIN lineage_graph l
-            ON (io.input_version_uuid = l.output_version_uuid OR io.output_version_uuid = l.input_version_uuid)
-           AND io.run_uuid != l.run_uuid
+          JOIN lineage_graph l ON io.input_version_uuid = l.output_version_uuid
+            AND io.run_uuid != l.run_uuid
+          WHERE l.depth < :depth
+            AND (:minDate::date IS NULL OR io.run_date >= :minDate::date)
+            AND (:maxDate::date IS NULL OR io.run_date <= :maxDate::date)
+
+          UNION ALL
+
+          -- downstream arm
+          SELECT
+            io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
+            io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
+            io.input_dataset_uuid, io.output_version_uuid, io.output_dataset_uuid,
+            io.input_dataset_namespace, io.input_dataset_name, io.input_dataset_version,
+            io.input_dataset_version_uuid, io.output_dataset_namespace, io.output_dataset_name,
+            io.output_dataset_version, io.output_dataset_version_uuid, io.uuid, io.parent_run_uuid,
+            io.input_uuids, io.output_uuids,
+            l.depth + 1 AS depth
+          FROM run_parent_lineage_denormalized io
+          JOIN lineage_graph l ON io.output_version_uuid = l.input_version_uuid
+            AND io.run_uuid != l.run_uuid
           WHERE l.depth < :depth
             AND (:minDate::date IS NULL OR io.run_date >= :minDate::date)
             AND (:maxDate::date IS NULL OR io.run_date <= :maxDate::date)
@@ -650,7 +735,7 @@ public interface LineageDao {
          LEFT JOIN (
              SELECT dvf.uuid AS dataset_uuid, JSONB_AGG(dvf.facet ORDER BY dvf.lineage_event_time ASC) AS facets
              FROM selected_dataset_version_facets dvf
-             WHERE dvf.run_uuid = dvf.run_uuid
+             WHERE dvf.run_uuid = dv.run_uuid
              GROUP BY dvf.uuid
          ) f ON f.dataset_uuid = dv.uuid""")
   Set<DatasetVersionData> getDatasetVersionData(

--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -675,11 +675,12 @@ public interface LineageDao {
              GROUP BY m.dataset_uuid
          ) t ON t.dataset_uuid = dv.dataset_uuid
          LEFT JOIN (
-             SELECT dvf.uuid AS dataset_uuid, JSONB_AGG(dvf.facet ORDER BY dvf.lineage_event_time ASC) AS facets
+             SELECT dvf.uuid AS dataset_uuid, dvf.run_uuid,
+                    JSONB_AGG(dvf.facet ORDER BY dvf.lineage_event_time ASC) AS facets
              FROM selected_dataset_version_facets dvf
-             WHERE dvf.run_uuid = dv.run_uuid
-             GROUP BY dvf.uuid
-         ) f ON f.dataset_uuid = dv.uuid""")
+             WHERE dvf.run_uuid IS NOT NULL
+             GROUP BY dvf.uuid, dvf.run_uuid
+         ) f ON f.dataset_uuid = dv.uuid AND f.run_uuid = dv.run_uuid""")
   Set<DatasetVersionData> getDatasetVersionData(
       @BindList(value = "versions", onEmpty = BindList.EmptyHandling.NULL_STRING)
           Set<UUID> versions);

--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -295,9 +295,6 @@ public interface LineageDao {
 
           UNION ALL
 
-          -- A recursive CTE allows only ONE recursive term, so both traversal
-          -- directions (this run consumed a version produced upstream, or produced a
-          -- version consumed downstream) must share a single self-referential arm.
           SELECT
             io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
             io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
@@ -328,24 +325,15 @@ public interface LineageDao {
         job_name,
         COALESCE(input_uuids, Array[]::uuid[]) AS input_uuids,
         COALESCE(output_uuids, Array[]::uuid[]) AS output_uuids,
-        (SELECT JSON_AGG(obj) FROM (
-            SELECT DISTINCT ON (input_dataset_version_uuid)
-                jsonb_build_object('namespace', input_dataset_namespace,
-                                   'name', input_dataset_name,
-                                   'version', input_dataset_version,
-                                   'dataset_version_uuid', input_dataset_version_uuid) AS obj
-            FROM lineage sub WHERE sub.run_uuid = lineage.run_uuid AND input_dataset_name IS NOT NULL
-            ORDER BY input_dataset_version_uuid
-        ) dedup_in) AS input_versions,
-        (SELECT JSON_AGG(obj) FROM (
-            SELECT DISTINCT ON (output_dataset_version_uuid)
-                jsonb_build_object('namespace', output_dataset_namespace,
-                                   'name', output_dataset_name,
-                                   'version', output_dataset_version,
-                                   'dataset_version_uuid', output_dataset_version_uuid) AS obj
-            FROM lineage sub WHERE sub.run_uuid = lineage.run_uuid AND output_dataset_name IS NOT NULL
-            ORDER BY output_dataset_version_uuid
-        ) dedup_out) AS output_versions,
+        JSON_AGG(DISTINCT jsonb_build_object('namespace', input_dataset_namespace,
+                    'name', input_dataset_name,
+                    'version', input_dataset_version,
+                    'dataset_version_uuid', input_dataset_version_uuid)) FILTER (WHERE input_dataset_name IS NOT NULL) AS input_versions,
+        JSON_AGG(DISTINCT jsonb_build_object('namespace', output_dataset_namespace,
+                                                            'name', output_dataset_name,
+                                                            'version', output_dataset_version,
+                                                            'dataset_version_uuid', output_dataset_version_uuid
+                                                            )) FILTER (WHERE output_dataset_name IS NOT NULL) AS output_versions,
         COALESCE(Array_AGG(distinct uuid) FILTER (WHERE uuid IS NOT NULL), Array[]::uuid[]) as child_run_id,
         COALESCE(Array_AGG(distinct parent_run_uuid) FILTER (WHERE parent_run_uuid IS NOT NULL), Array[]::uuid[]) as parent_run_id,
         MIN(depth) AS depth
@@ -381,8 +369,6 @@ public interface LineageDao {
 
           UNION ALL
 
-          -- A recursive CTE allows only ONE recursive term, so both traversal
-          -- directions share a single self-referential arm.
           SELECT
             io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
             io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
@@ -416,24 +402,15 @@ public interface LineageDao {
         l.job_name,
         COALESCE(l.input_uuids, Array[]::uuid[]) AS input_uuids,
         COALESCE(l.output_uuids, Array[]::uuid[]) AS output_uuids,
-        (SELECT JSON_AGG(obj) FROM (
-            SELECT DISTINCT ON (input_dataset_version_uuid)
-                jsonb_build_object('namespace', input_dataset_namespace,
-                                   'name', input_dataset_name,
-                                   'version', input_dataset_version,
-                                   'dataset_version_uuid', input_dataset_version_uuid) AS obj
-            FROM lineage_graph sub WHERE sub.run_uuid = l.run_uuid AND input_dataset_name IS NOT NULL
-            ORDER BY input_dataset_version_uuid
-        ) dedup_in) AS input_versions,
-        (SELECT JSON_AGG(obj) FROM (
-            SELECT DISTINCT ON (output_dataset_version_uuid)
-                jsonb_build_object('namespace', output_dataset_namespace,
-                                   'name', output_dataset_name,
-                                   'version', output_dataset_version,
-                                   'dataset_version_uuid', output_dataset_version_uuid) AS obj
-            FROM lineage_graph sub WHERE sub.run_uuid = l.run_uuid AND output_dataset_name IS NOT NULL
-            ORDER BY output_dataset_version_uuid
-        ) dedup_out) AS output_versions,
+        JSON_AGG(DISTINCT jsonb_build_object('namespace', l.input_dataset_namespace,
+                    'name', l.input_dataset_name,
+                    'version', l.input_dataset_version,
+                    'dataset_version_uuid', l.input_dataset_version_uuid)) FILTER (WHERE l.input_dataset_name IS NOT NULL) AS input_versions,
+        JSON_AGG(DISTINCT jsonb_build_object('namespace', l.output_dataset_namespace,
+                                                            'name', l.output_dataset_name,
+                                                            'version', l.output_dataset_version,
+                                                            'dataset_version_uuid', l.output_dataset_version_uuid
+                                                            )) FILTER (WHERE l.output_dataset_name IS NOT NULL) AS output_versions,
         COALESCE(Array_AGG(distinct l.uuid) FILTER (WHERE l.uuid IS NOT NULL), Array[]::uuid[]) as child_run_id,
         COALESCE(Array_AGG(distinct l.parent_run_uuid) FILTER (WHERE l.parent_run_uuid IS NOT NULL), Array[]::uuid[]) as parent_run_id,
         JSON_AGG(DISTINCT jsonb_build_object(rf.name, rf.facet)) FILTER (WHERE rf.name IS NOT NULL) as facets,
@@ -509,8 +486,6 @@ public interface LineageDao {
 
              UNION ALL
 
-             -- A recursive CTE allows only ONE recursive term, so both traversal
-             -- directions share a single self-referential arm.
              SELECT
                io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
                io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,
@@ -590,8 +565,6 @@ public interface LineageDao {
 
           UNION ALL
 
-          -- A recursive CTE allows only ONE recursive term, so both traversal
-          -- directions share a single self-referential arm.
           SELECT
             io.run_uuid, io.namespace_name, io.job_name, io.state, io.created_at, io.updated_at,
             io.started_at, io.ended_at, io.job_uuid, io.job_version_uuid, io.input_version_uuid,

--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -658,6 +658,46 @@ public interface LineageDao {
       @BindList(value = "versions", onEmpty = BindList.EmptyHandling.NULL_STRING)
           Set<UUID> versions);
 
+  /**
+   * One forward hop of the lineage_edges BFS read path: the {@code to_node_id}s of edges of a given
+   * {@code edge_type} whose {@code from_node_id} is in the frontier. The run_date range prunes the
+   * RANGE(run_date)→HASH(namespace) partitions; pass NULL bounds to scan all partitions.
+   */
+  @SqlQuery(
+      """
+      SELECT DISTINCT to_node_id
+      FROM lineage_edges
+      WHERE from_node_id IN (<nodeIds>)
+        AND edge_type = :edgeType
+        AND (:minDate::date IS NULL OR run_date >= :minDate::date)
+        AND (:maxDate::date IS NULL OR run_date <= :maxDate::date)
+      """)
+  Set<UUID> findLineageEdgeTargets(
+      @BindList(value = "nodeIds", onEmpty = BindList.EmptyHandling.NULL_STRING) Set<UUID> nodeIds,
+      @Bind("edgeType") String edgeType,
+      @Bind("minDate") String minDate,
+      @Bind("maxDate") String maxDate);
+
+  /**
+   * One backward hop of the lineage_edges BFS read path: the {@code from_node_id}s of edges of a
+   * given {@code edge_type} whose {@code to_node_id} is in the frontier. Mirror of {@link
+   * #findLineageEdgeTargets} for upstream traversal.
+   */
+  @SqlQuery(
+      """
+      SELECT DISTINCT from_node_id
+      FROM lineage_edges
+      WHERE to_node_id IN (<nodeIds>)
+        AND edge_type = :edgeType
+        AND (:minDate::date IS NULL OR run_date >= :minDate::date)
+        AND (:maxDate::date IS NULL OR run_date <= :maxDate::date)
+      """)
+  Set<UUID> findLineageEdgeSources(
+      @BindList(value = "nodeIds", onEmpty = BindList.EmptyHandling.NULL_STRING) Set<UUID> nodeIds,
+      @Bind("edgeType") String edgeType,
+      @Bind("minDate") String minDate,
+      @Bind("maxDate") String maxDate);
+
   @SqlQuery(
       """
       WITH RECURSIVE

--- a/api/src/main/java/marquez/db/RunFacetsDao.java
+++ b/api/src/main/java/marquez/db/RunFacetsDao.java
@@ -47,14 +47,16 @@ public interface RunFacetsDao {
          lineage_event_time,
          lineage_event_type,
          name,
-         facet
+         facet,
+         namespace
       ) VALUES (
          :createdAt,
          :runUuid,
          :lineageEventTime,
          :lineageEventType,
          :name,
-         :facet
+         :facet,
+         (SELECT namespace_name FROM runs WHERE uuid = :runUuid)
       )
       """)
   void insertRunFacet(

--- a/api/src/main/java/marquez/jobs/PartitionManagementJob.java
+++ b/api/src/main/java/marquez/jobs/PartitionManagementJob.java
@@ -83,6 +83,16 @@ public class PartitionManagementJob extends AbstractScheduledService implements 
 
       partitionManagementService.createPartitionsForPeriod(startDate, totalMonths);
 
+      // Also provision the composite RANGE->HASH subtrees (lineage_edges / run_facets). Wrapped
+      // independently so a missing helper/parent (e.g. migrateOnStartup=false on an older schema)
+      // doesn't block the denormalized-table partitioning above.
+      try {
+        partitionManagementService.createCompositePartitionsForPeriod(startDate, totalMonths);
+      } catch (Exception error) {
+        log.error(
+            "Failed to create composite partitions. Will retry on next scheduled run.", error);
+      }
+
       log.info(
           "Partition management completed successfully. Ensured partitions exist from {} for {} months.",
           startDate,
@@ -90,6 +100,15 @@ public class PartitionManagementJob extends AbstractScheduledService implements 
 
     } catch (Exception error) {
       log.error("Failed to create partitions. Will retry on next scheduled run.", error);
+    }
+
+    // Retention: drop composite (lineage_edges / run_facets) partitions past their window. Kept
+    // separate from creation so a cleanup failure never blocks future-partition provisioning.
+    try {
+      partitionManagementService.cleanupOldCompositePartitions();
+    } catch (Exception error) {
+      log.error(
+          "Failed to drop old composite partitions. Will retry on next scheduled run.", error);
     }
   }
 

--- a/api/src/main/java/marquez/jobs/backfill/AbstractPartitionCutoverBackfillJob.java
+++ b/api/src/main/java/marquez/jobs/backfill/AbstractPartitionCutoverBackfillJob.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2018-2024 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.jobs.backfill;
+
+import java.time.Instant;
+import java.util.List;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import marquez.jobs.BackfillConfig;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+
+/**
+ * Shared online cutover for converting a large, keyless, INSERT-only table into a partitioned one
+ * without blocking startup. The size-branched migration (e.g. V108/V111) arms the cutover on a
+ * large table: it builds the empty partitioned shadow, installs an {@code AFTER INSERT} trigger
+ * that mirrors rows with {@code boundaryColumn >= cutover} into the shadow, and records {@code
+ * cutover} + {@code state='DUAL_WRITE'} in a per-table state marker. A concrete subclass of this
+ * job then, in the background:
+ *
+ * <ol>
+ *   <li><strong>Bulk copy</strong> — copies history ({@code boundaryColumn < cutover}) into the
+ *       shadow in ctid-keyset batches, checkpointed in {@code backfill_checkpoints}. The trigger
+ *       owns everything at/after the cutover, so the two sets are disjoint by value: exactly-once,
+ *       no primary key required.
+ *   <li><strong>Verified swap</strong> — takes a brief {@code ACCESS EXCLUSIVE} lock, confirms
+ *       {@code count(table) == count(shadow)} (both frozen), and only then atomically renames the
+ *       shadow into place, restores dependents (FKs, view), and drops the trigger and old table.
+ *       The old table is the source of truth until this verified swap, so an interrupted copy or a
+ *       count mismatch loses nothing — it aborts and retries.
+ * </ol>
+ *
+ * <p>On a small/empty database the migration already swapped inline (state {@code SWAPPED}); this
+ * job detects that and no-ops. Subclasses supply only the table-specific SQL fragments.
+ */
+@Slf4j
+public abstract class AbstractPartitionCutoverBackfillJob implements BackfillJob {
+
+  protected final Jdbi jdbi;
+  protected final BackfillConfig config;
+
+  protected AbstractPartitionCutoverBackfillJob(
+      @NonNull Jdbi jdbi, @NonNull BackfillConfig config) {
+    this.jdbi = jdbi;
+    this.config = config;
+  }
+
+  // --- per-table specification -------------------------------------------------
+
+  /** The live table being partitioned, e.g. {@code run_facets}. */
+  protected abstract String table();
+
+  /** The empty partitioned shadow the migration created, e.g. {@code run_facets_p}. */
+  protected abstract String shadow();
+
+  /** Single-row cutover state marker table, e.g. {@code run_facets_partition_state}. */
+  protected abstract String stateTable();
+
+  /** The dual-write trigger name, dropped at swap, e.g. {@code run_facets_mirror_trg}. */
+  protected abstract String triggerName();
+
+  /** NOT NULL write-time column defining the copy/trigger boundary, e.g. {@code created_at}. */
+  protected abstract String boundaryColumn();
+
+  /** Column list for the shadow INSERT (matching {@link #selectExpr()}). */
+  protected abstract String insertColumns();
+
+  /** SELECT expression over alias {@code o} for the copy (resolves namespace, etc.). */
+  protected abstract String selectExpr();
+
+  /** DDL to run before the rename (e.g. drop the dependent view that pins the old table). */
+  protected abstract List<String> preSwapDdl();
+
+  /** DDL to run after the rename (re-add FKs, recreate the view). */
+  protected abstract List<String> postSwapDdl();
+
+  // --- orchestration -----------------------------------------------------------
+
+  @Override
+  public void run() throws Exception {
+    if (isCompleted()) {
+      log.info("{}: already completed — skipping.", version());
+      return;
+    }
+
+    String state = readState();
+    if (!"DUAL_WRITE".equals(state)) {
+      log.info(
+          "{}: state='{}' (not DUAL_WRITE) — swapped inline or not armed; nothing to do.",
+          version(),
+          state);
+      markCompleted();
+      return;
+    }
+    if (isTablePartitioned()) {
+      log.info("{}: {} already partitioned — marking done.", version(), table());
+      markCompleted();
+      return;
+    }
+
+    Instant cutover = readCutover();
+    log.info("{}: starting online copy of {} rows created before {}.", version(), table(), cutover);
+
+    long copied = runBulkCopy(cutover);
+    log.info("{}: bulk copy drained after {} rows this run.", version(), copied);
+
+    if (Thread.currentThread().isInterrupted()) {
+      log.info("{}: interrupted before swap — will resume on restart.", version());
+      return;
+    }
+
+    performVerifiedSwap();
+  }
+
+  private long runBulkCopy(Instant cutover) throws InterruptedException {
+    String lastCtid = readCheckpointCtid();
+    long total = 0;
+
+    // Alias the projection: an unaliased `ctid::text` is output-named `ctid`, and ORDER BY would
+    // then bind to that TEXT column (lexical order: '(0,10)' < '(0,2)') instead of the tid column,
+    // corrupting the keyset.
+    final String selectCtids =
+        "SELECT ctid::text AS ctid_text FROM "
+            + table()
+            + " WHERE "
+            + boundaryColumn()
+            + " < :cutover AND ctid > :from::tid"
+            + " ORDER BY ctid LIMIT :batchSize";
+    final String copyBatch =
+        "INSERT INTO "
+            + shadow()
+            + " ("
+            + insertColumns()
+            + ") SELECT "
+            + selectExpr()
+            + " FROM "
+            + table()
+            + " o WHERE o.ctid = ANY(:ctids::tid[])";
+
+    while (true) {
+      if (Thread.currentThread().isInterrupted()) {
+        throw new InterruptedException("Interrupted during " + table() + " bulk copy");
+      }
+
+      final String from = lastCtid;
+      List<String> ctids =
+          jdbi.withHandle(
+              handle ->
+                  handle
+                      .createQuery(selectCtids)
+                      .bind("cutover", cutover)
+                      .bind("from", from)
+                      .bind("batchSize", config.getBatchSize())
+                      .mapTo(String.class)
+                      .list());
+
+      if (ctids.isEmpty()) {
+        break;
+      }
+
+      final String batchLast = ctids.get(ctids.size() - 1);
+      jdbi.useTransaction(
+          handle -> {
+            handle.createUpdate(copyBatch).bindArray("ctids", String.class, ctids).execute();
+            saveCheckpointCtid(handle, batchLast);
+          });
+
+      lastCtid = batchLast;
+      total += ctids.size();
+      maybeSleep();
+    }
+    return total;
+  }
+
+  private void performVerifiedSwap() {
+    jdbi.useTransaction(
+        handle -> {
+          handle.execute("LOCK TABLE " + table() + " IN ACCESS EXCLUSIVE MODE");
+
+          long oldCount = countOf(handle, table());
+          long shadowCount = countOf(handle, shadow());
+          if (oldCount != shadowCount) {
+            // Old table is still intact. Do NOT swap; abort so nothing changes and leave
+            // state=DUAL_WRITE to retry. A persistent mismatch is resolved by rebuilding the
+            // shadow.
+            throw new IllegalStateException(
+                String.format(
+                    "%s swap aborted: count mismatch old=%d shadow=%d — not swapping, old table"
+                        + " preserved. Will retry.",
+                    table(), oldCount, shadowCount));
+          }
+
+          for (String ddl : preSwapDdl()) {
+            handle.execute(ddl);
+          }
+          handle.execute("DROP TRIGGER IF EXISTS " + triggerName() + " ON " + table());
+          handle.execute("ALTER TABLE " + table() + " RENAME TO " + table() + "_old");
+          handle.execute("ALTER TABLE " + shadow() + " RENAME TO " + table());
+          for (String ddl : postSwapDdl()) {
+            handle.execute(ddl);
+          }
+          handle.execute("DROP TABLE " + table() + "_old");
+          handle.execute("UPDATE " + stateTable() + " SET state = 'SWAPPED'");
+        });
+    markCompleted();
+    log.info("{}: verified swap complete — {} is partitioned.", version(), table());
+  }
+
+  private long countOf(Handle handle, String t) {
+    return handle.createQuery("SELECT count(*) FROM " + t).mapTo(Long.class).one();
+  }
+
+  // --- state + checkpoint helpers ---------------------------------------------
+
+  private String readState() {
+    return jdbi.withHandle(
+        handle ->
+            handle
+                .createQuery("SELECT state FROM " + stateTable() + " LIMIT 1")
+                .mapTo(String.class)
+                .findOne()
+                .orElse("NONE"));
+  }
+
+  private Instant readCutover() {
+    return jdbi.withHandle(
+        handle ->
+            handle
+                .createQuery("SELECT cutover_at FROM " + stateTable() + " LIMIT 1")
+                .mapTo(Instant.class)
+                .one());
+  }
+
+  private boolean isTablePartitioned() {
+    return jdbi.withHandle(
+        handle ->
+            handle
+                .createQuery(
+                    "SELECT EXISTS(SELECT 1 FROM pg_partitioned_table WHERE partrelid ="
+                        + " to_regclass(:t))")
+                .bind("t", table())
+                .mapTo(Boolean.class)
+                .one());
+  }
+
+  private boolean isCompleted() {
+    try {
+      return jdbi.withHandle(
+          handle ->
+              handle
+                  .createQuery(
+                      "SELECT completed_at IS NOT NULL FROM backfill_checkpoints WHERE version ="
+                          + " :version")
+                  .bind("version", version())
+                  .mapTo(Boolean.class)
+                  .findOne()
+                  .orElse(false));
+    } catch (Exception e) {
+      log.warn("{}: could not check completed_at — assuming not done.", version());
+      return false;
+    }
+  }
+
+  private void markCompleted() {
+    jdbi.useHandle(
+        handle ->
+            handle
+                .createUpdate(
+                    """
+                    INSERT INTO backfill_checkpoints (version, last_cursor_time, last_run_id, completed_at, updated_at)
+                    VALUES (:version, now(), '', now(), now())
+                    ON CONFLICT (version) DO UPDATE SET completed_at = now(), updated_at = now()
+                    """)
+                .bind("version", version())
+                .execute());
+  }
+
+  private String readCheckpointCtid() {
+    return jdbi.withHandle(
+        handle ->
+            handle
+                .createQuery(
+                    "SELECT last_run_id FROM backfill_checkpoints WHERE version = :version")
+                .bind("version", version())
+                .mapTo(String.class)
+                .findOne()
+                .filter(s -> !s.isEmpty())
+                .orElse("(0,0)"));
+  }
+
+  private void saveCheckpointCtid(Handle handle, String lastCtid) {
+    handle
+        .createUpdate(
+            """
+            INSERT INTO backfill_checkpoints (version, last_cursor_time, last_run_id, updated_at)
+            VALUES (:version, '1970-01-01 00:00:00+00', :lastCtid, now())
+            ON CONFLICT (version) DO UPDATE SET last_run_id = EXCLUDED.last_run_id, updated_at = now()
+            """)
+        .bind("version", version())
+        .bind("lastCtid", lastCtid)
+        .execute();
+  }
+
+  private void maybeSleep() throws InterruptedException {
+    long delay = config.getDelayBetweenBatchesMs();
+    if (delay > 0) {
+      Thread.sleep(delay);
+    }
+  }
+}

--- a/api/src/main/java/marquez/jobs/backfill/AbstractPartitionCutoverBackfillJob.java
+++ b/api/src/main/java/marquez/jobs/backfill/AbstractPartitionCutoverBackfillJob.java
@@ -62,8 +62,23 @@ public abstract class AbstractPartitionCutoverBackfillJob implements BackfillJob
   /** The dual-write trigger name, dropped at swap, e.g. {@code run_facets_mirror_trg}. */
   protected abstract String triggerName();
 
-  /** NOT NULL write-time column defining the copy/trigger boundary, e.g. {@code created_at}. */
+  /** Write-time column defining the copy/trigger boundary, e.g. {@code created_at}. */
   protected abstract String boundaryColumn();
+
+  /**
+   * Predicate (over the live table, binding {@code :cutover}) selecting the rows the backfill owns
+   * — the complement of what the {@code >= cutover} trigger mirrors. Default {@code col <
+   * :cutover}; override to treat pre-existing NULLs as historical when the boundary column is
+   * nullable.
+   */
+  protected String copyBoundaryPredicate() {
+    return boundaryColumn() + " < :cutover";
+  }
+
+  /**
+   * Hook run after the swap transaction commits (e.g. refresh a dependent matview). No-op default.
+   */
+  protected void afterSwapCommitted() {}
 
   /** Column list for the shadow INSERT (matching {@link #selectExpr()}). */
   protected abstract String insertColumns();
@@ -125,9 +140,9 @@ public abstract class AbstractPartitionCutoverBackfillJob implements BackfillJob
     final String selectCtids =
         "SELECT ctid::text AS ctid_text FROM "
             + table()
-            + " WHERE "
-            + boundaryColumn()
-            + " < :cutover AND ctid > :from::tid"
+            + " WHERE ("
+            + copyBoundaryPredicate()
+            + ") AND ctid > :from::tid"
             + " ORDER BY ctid LIMIT :batchSize";
     final String copyBatch =
         "INSERT INTO "
@@ -205,6 +220,7 @@ public abstract class AbstractPartitionCutoverBackfillJob implements BackfillJob
           handle.execute("DROP TABLE " + table() + "_old");
           handle.execute("UPDATE " + stateTable() + " SET state = 'SWAPPED'");
         });
+    afterSwapCommitted();
     markCompleted();
     log.info("{}: verified swap complete — {} is partitioned.", version(), table());
   }

--- a/api/src/main/java/marquez/jobs/backfill/DatasetFacetsPartitionBackfillJob.java
+++ b/api/src/main/java/marquez/jobs/backfill/DatasetFacetsPartitionBackfillJob.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018-2024 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.jobs.backfill;
+
+import java.util.List;
+import lombok.NonNull;
+import marquez.jobs.BackfillConfig;
+import org.jdbi.v3.core.Jdbi;
+
+/**
+ * Online cutover that partitions {@code dataset_facets} on a large existing database (V111). See
+ * {@link AbstractPartitionCutoverBackfillJob} for the copy + verified-swap mechanics.
+ */
+public class DatasetFacetsPartitionBackfillJob extends AbstractPartitionCutoverBackfillJob {
+
+  public static final String VERSION = "DATASET_FACETS_PARTITION_V1";
+
+  public DatasetFacetsPartitionBackfillJob(@NonNull Jdbi jdbi, @NonNull BackfillConfig config) {
+    super(jdbi, config);
+  }
+
+  @Override
+  public String version() {
+    return VERSION;
+  }
+
+  @Override
+  protected String table() {
+    return "dataset_facets";
+  }
+
+  @Override
+  protected String shadow() {
+    return "dataset_facets_p";
+  }
+
+  @Override
+  protected String stateTable() {
+    return "dataset_facets_partition_state";
+  }
+
+  @Override
+  protected String triggerName() {
+    return "dataset_facets_mirror_trg";
+  }
+
+  @Override
+  protected String boundaryColumn() {
+    return "created_at";
+  }
+
+  @Override
+  protected String insertColumns() {
+    return "created_at, dataset_uuid, dataset_version_uuid, run_uuid, lineage_event_time,"
+        + " lineage_event_type, type, name, facet, namespace";
+  }
+
+  @Override
+  protected String selectExpr() {
+    return "o.created_at, o.dataset_uuid, o.dataset_version_uuid, o.run_uuid, o.lineage_event_time,"
+        + " o.lineage_event_type, o.type, o.name, o.facet,"
+        + " COALESCE(o.namespace, (SELECT namespace_name FROM runs WHERE uuid = o.run_uuid))";
+  }
+
+  @Override
+  protected List<String> preSwapDdl() {
+    return List.of("DROP VIEW IF EXISTS dataset_facets_view");
+  }
+
+  @Override
+  protected List<String> postSwapDdl() {
+    return List.of(
+        "ALTER TABLE dataset_facets ADD CONSTRAINT dataset_facets_dataset_uuid_fkey"
+            + " FOREIGN KEY (dataset_uuid) REFERENCES datasets (uuid) ON DELETE CASCADE",
+        "ALTER TABLE dataset_facets ADD CONSTRAINT dataset_facets_dataset_version_uuid_fkey"
+            + " FOREIGN KEY (dataset_version_uuid) REFERENCES dataset_versions (uuid) ON DELETE"
+            + " CASCADE",
+        "ALTER TABLE dataset_facets ADD CONSTRAINT dataset_facets_run_uuid_fkey"
+            + " FOREIGN KEY (run_uuid) REFERENCES runs (uuid) ON DELETE CASCADE",
+        "CREATE VIEW dataset_facets_view AS SELECT created_at, dataset_uuid, dataset_version_uuid,"
+            + " run_uuid, lineage_event_time, lineage_event_type, type, name, facet FROM"
+            + " dataset_facets");
+  }
+}

--- a/api/src/main/java/marquez/jobs/backfill/LineageEventsPartitionBackfillJob.java
+++ b/api/src/main/java/marquez/jobs/backfill/LineageEventsPartitionBackfillJob.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018-2024 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.jobs.backfill;
+
+import java.util.List;
+import lombok.NonNull;
+import marquez.jobs.BackfillConfig;
+import org.jdbi.v3.core.Jdbi;
+
+/**
+ * Online cutover that partitions {@code lineage_events} on a large existing database (V112). See
+ * {@link AbstractPartitionCutoverBackfillJob} for the copy + verified-swap mechanics.
+ *
+ * <p>Two differences from the facet tables: it HASH-partitions on the existing {@code
+ * job_namespace} (no namespace resolution), and its dependent is the actively refreshed matview
+ * {@code lineage_events_by_type_hourly_view} — dropped before the rename, recreated {@code WITH NO
+ * DATA} after (instant, keeping the swap lock short), then repopulated by {@link
+ * #afterSwapCommitted()}. Historical rows may predate the {@code created_at} column, so NULLs are
+ * treated as historical.
+ */
+public class LineageEventsPartitionBackfillJob extends AbstractPartitionCutoverBackfillJob {
+
+  public static final String VERSION = "LINEAGE_EVENTS_PARTITION_V1";
+
+  private static final String MATVIEW_DEF =
+      "CREATE MATERIALIZED VIEW lineage_events_by_type_hourly_view AS SELECT date_trunc('hour',"
+          + " event_time) AS start_interval, count(*) FILTER (WHERE event_type = 'FAIL') AS fail,"
+          + " count(*) FILTER (WHERE event_type = 'START') AS start, count(*) FILTER (WHERE"
+          + " event_type = 'COMPLETE') AS complete, count(*) FILTER (WHERE event_type = 'ABORT') AS"
+          + " abort FROM lineage_events GROUP BY date_trunc('hour', event_time)";
+
+  public LineageEventsPartitionBackfillJob(@NonNull Jdbi jdbi, @NonNull BackfillConfig config) {
+    super(jdbi, config);
+  }
+
+  @Override
+  public String version() {
+    return VERSION;
+  }
+
+  @Override
+  protected String table() {
+    return "lineage_events";
+  }
+
+  @Override
+  protected String shadow() {
+    return "lineage_events_p";
+  }
+
+  @Override
+  protected String stateTable() {
+    return "lineage_events_partition_state";
+  }
+
+  @Override
+  protected String triggerName() {
+    return "lineage_events_mirror_trg";
+  }
+
+  @Override
+  protected String boundaryColumn() {
+    return "created_at";
+  }
+
+  @Override
+  protected String copyBoundaryPredicate() {
+    // created_at was added later; pre-existing rows may be NULL. New rows always get its
+    // DEFAULT now(), so NULLs only exist in history — treat them as the backfill's to own.
+    return "created_at < :cutover OR created_at IS NULL";
+  }
+
+  @Override
+  protected String insertColumns() {
+    return "event_time, event, event_type, job_name, job_namespace, producer, run_uuid,"
+        + " created_at, _event_type, run_date";
+  }
+
+  @Override
+  protected String selectExpr() {
+    return "o.event_time, o.event, o.event_type, o.job_name, o.job_namespace, o.producer,"
+        + " o.run_uuid, o.created_at, o._event_type, o.run_date";
+  }
+
+  @Override
+  protected List<String> preSwapDdl() {
+    return List.of("DROP MATERIALIZED VIEW IF EXISTS lineage_events_by_type_hourly_view");
+  }
+
+  @Override
+  protected List<String> postSwapDdl() {
+    // WITH NO DATA keeps the swap lock instant; afterSwapCommitted() populates it.
+    return List.of(MATVIEW_DEF + " WITH NO DATA");
+  }
+
+  @Override
+  protected void afterSwapCommitted() {
+    jdbi.useHandle(
+        handle -> handle.execute("REFRESH MATERIALIZED VIEW lineage_events_by_type_hourly_view"));
+  }
+}

--- a/api/src/main/java/marquez/jobs/backfill/RunFacetsPartitionBackfillJob.java
+++ b/api/src/main/java/marquez/jobs/backfill/RunFacetsPartitionBackfillJob.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2018-2024 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.jobs.backfill;
+
+import java.time.Instant;
+import java.util.List;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import marquez.jobs.BackfillConfig;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+
+/**
+ * Online cutover for partitioning {@code run_facets} on a large existing database, mirroring what
+ * V108 does inline on a small/empty one — but without blocking startup.
+ *
+ * <p>V108 arms the cutover for a large table: it builds the empty partitioned shadow {@code
+ * run_facets_p}, installs an {@code AFTER INSERT} trigger that mirrors every row with {@code
+ * created_at >= cutover} into the shadow, and records {@code cutover} in {@code
+ * run_facets_partition_state}. This job then, in the background:
+ *
+ * <ol>
+ *   <li><strong>Bulk copy</strong> — copies the historical rows ({@code created_at < cutover}) into
+ *       the shadow in ctid-keyset batches, checkpointed in {@code backfill_checkpoints} so a
+ *       restart resumes without re-copying. The trigger owns everything at/after the cutover, so
+ *       the two sets are disjoint by value: exactly-once, no primary key required.
+ *   <li><strong>Verified swap</strong> — once the copy drains, it takes a brief {@code ACCESS
+ *       EXCLUSIVE} lock, confirms {@code count(run_facets) == count(run_facets_p)} (both frozen),
+ *       and only then atomically renames the shadow into place, restores the FK + view, and drops
+ *       the trigger and old table. The old table is the source of truth until this verified swap,
+ *       so an interrupted copy or a count mismatch loses nothing — it simply retries.
+ * </ol>
+ *
+ * <p>On a small/empty database V108 already swapped inline (state {@code SWAPPED}); this job then
+ * detects the finished state and no-ops.
+ */
+@Slf4j
+public class RunFacetsPartitionBackfillJob implements BackfillJob {
+
+  public static final String VERSION = "RUN_FACETS_PARTITION_V1";
+
+  private final Jdbi jdbi;
+  private final BackfillConfig config;
+
+  public RunFacetsPartitionBackfillJob(@NonNull Jdbi jdbi, @NonNull BackfillConfig config) {
+    this.jdbi = jdbi;
+    this.config = config;
+  }
+
+  @Override
+  public String version() {
+    return VERSION;
+  }
+
+  @Override
+  public void run() throws Exception {
+    if (isCompleted()) {
+      log.info("RunFacetsPartitionBackfillJob: already completed — skipping.");
+      return;
+    }
+
+    // Nothing to do unless V108 armed an online cutover on a large table.
+    String state = readState();
+    if (!"DUAL_WRITE".equals(state)) {
+      log.info(
+          "RunFacetsPartitionBackfillJob: state='{}' (not DUAL_WRITE) — run_facets was partitioned"
+              + " inline or is not armed; nothing to do.",
+          state);
+      markCompleted();
+      return;
+    }
+    if (isRunFacetsPartitioned()) {
+      log.info("RunFacetsPartitionBackfillJob: run_facets already partitioned — marking done.");
+      markCompleted();
+      return;
+    }
+
+    Instant cutover = readCutover();
+    log.info(
+        "RunFacetsPartitionBackfillJob: starting online copy of rows created before {}.", cutover);
+
+    long copied = runBulkCopy(cutover);
+    log.info("RunFacetsPartitionBackfillJob: bulk copy drained after {} rows this run.", copied);
+
+    if (Thread.currentThread().isInterrupted()) {
+      log.info("RunFacetsPartitionBackfillJob: interrupted before swap — will resume on restart.");
+      return;
+    }
+
+    performVerifiedSwap();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bulk copy — ctid keyset, one transaction per batch, checkpointed.
+  // ---------------------------------------------------------------------------
+
+  private long runBulkCopy(Instant cutover) throws InterruptedException {
+    String lastCtid = readCheckpointCtid();
+    long total = 0;
+
+    while (true) {
+      if (Thread.currentThread().isInterrupted()) {
+        throw new InterruptedException("Interrupted during run_facets bulk copy");
+      }
+
+      final String from = lastCtid;
+      List<String> ctids =
+          jdbi.withHandle(
+              handle ->
+                  handle
+                      .createQuery(
+                          // Alias the projection: an unaliased `ctid::text` is output-named `ctid`,
+                          // and ORDER BY would then bind to that TEXT column (lexical order:
+                          // '(0,10)' < '(0,2)') instead of the tid column, corrupting the keyset.
+                          """
+                          SELECT ctid::text AS ctid_text FROM run_facets
+                          WHERE created_at < :cutover AND ctid > :from::tid
+                          ORDER BY ctid
+                          LIMIT :batchSize
+                          """)
+                      .bind("cutover", cutover)
+                      .bind("from", from)
+                      .bind("batchSize", config.getBatchSize())
+                      .mapTo(String.class)
+                      .list());
+
+      if (ctids.isEmpty()) {
+        break;
+      }
+
+      final String batchLast = ctids.get(ctids.size() - 1);
+      jdbi.useTransaction(
+          handle -> {
+            handle
+                .createUpdate(
+                    """
+                    INSERT INTO run_facets_p (
+                        created_at, run_uuid, lineage_event_time, lineage_event_type,
+                        name, facet, namespace)
+                    SELECT o.created_at, o.run_uuid, o.lineage_event_time, o.lineage_event_type,
+                           o.name, o.facet,
+                           COALESCE(o.namespace,
+                                    (SELECT namespace_name FROM runs WHERE uuid = o.run_uuid))
+                    FROM run_facets o
+                    WHERE o.ctid = ANY(:ctids::tid[])
+                    """)
+                .bindArray("ctids", String.class, ctids)
+                .execute();
+            saveCheckpointCtid(handle, batchLast);
+          });
+
+      lastCtid = batchLast;
+      total += ctids.size();
+      maybeSleep();
+    }
+    return total;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Verified swap — brief ACCESS EXCLUSIVE lock, count parity, atomic rename.
+  // ---------------------------------------------------------------------------
+
+  private void performVerifiedSwap() {
+    jdbi.useTransaction(
+        handle -> {
+          // Freeze writers so old + shadow are static while we verify and swap.
+          handle.execute("LOCK TABLE run_facets IN ACCESS EXCLUSIVE MODE");
+
+          long oldCount = countOf(handle, "run_facets");
+          long shadowCount = countOf(handle, "run_facets_p");
+          if (oldCount != shadowCount) {
+            // Old table is still the source of truth and fully intact. Do NOT swap; abort the
+            // transaction so nothing changes, and leave state=DUAL_WRITE to retry. A persistent
+            // mismatch (e.g. a clock-skew boundary row) is resolved by rebuilding the shadow.
+            throw new IllegalStateException(
+                String.format(
+                    "run_facets swap aborted: count mismatch old=%d shadow=%d — not swapping,"
+                        + " old table preserved. Will retry.",
+                    oldCount, shadowCount));
+          }
+
+          handle.execute("DROP VIEW IF EXISTS run_facets_view");
+          handle.execute("DROP TRIGGER IF EXISTS run_facets_mirror_trg ON run_facets");
+          handle.execute("ALTER TABLE run_facets RENAME TO run_facets_old");
+          handle.execute("ALTER TABLE run_facets_p RENAME TO run_facets");
+          handle.execute(
+              "ALTER TABLE run_facets ADD CONSTRAINT run_facets_run_uuid_fkey"
+                  + " FOREIGN KEY (run_uuid) REFERENCES runs (uuid) ON DELETE CASCADE");
+          handle.execute(
+              "CREATE VIEW run_facets_view AS SELECT created_at, run_uuid, lineage_event_time,"
+                  + " lineage_event_type, name, facet FROM run_facets");
+          handle.execute("DROP TABLE run_facets_old");
+          handle.execute("UPDATE run_facets_partition_state SET state = 'SWAPPED'");
+        });
+    markCompleted();
+    log.info("RunFacetsPartitionBackfillJob: verified swap complete — run_facets is partitioned.");
+  }
+
+  private long countOf(Handle handle, String table) {
+    return handle.createQuery("SELECT count(*) FROM " + table).mapTo(Long.class).one();
+  }
+
+  // ---------------------------------------------------------------------------
+  // State + checkpoint helpers.
+  // ---------------------------------------------------------------------------
+
+  private String readState() {
+    return jdbi.withHandle(
+        handle ->
+            handle
+                .createQuery("SELECT state FROM run_facets_partition_state LIMIT 1")
+                .mapTo(String.class)
+                .findOne()
+                .orElse("NONE"));
+  }
+
+  private Instant readCutover() {
+    return jdbi.withHandle(
+        handle ->
+            handle
+                .createQuery("SELECT cutover_at FROM run_facets_partition_state LIMIT 1")
+                .mapTo(Instant.class)
+                .one());
+  }
+
+  private boolean isRunFacetsPartitioned() {
+    return jdbi.withHandle(
+        handle ->
+            handle
+                .createQuery(
+                    "SELECT EXISTS(SELECT 1 FROM pg_partitioned_table"
+                        + " WHERE partrelid = 'run_facets'::regclass)")
+                .mapTo(Boolean.class)
+                .one());
+  }
+
+  private boolean isCompleted() {
+    try {
+      return jdbi.withHandle(
+          handle ->
+              handle
+                  .createQuery(
+                      "SELECT completed_at IS NOT NULL FROM backfill_checkpoints"
+                          + " WHERE version = :version")
+                  .bind("version", VERSION)
+                  .mapTo(Boolean.class)
+                  .findOne()
+                  .orElse(false));
+    } catch (Exception e) {
+      log.warn("RunFacetsPartitionBackfillJob: could not check completed_at — assuming not done.");
+      return false;
+    }
+  }
+
+  private void markCompleted() {
+    jdbi.useHandle(
+        handle ->
+            handle
+                .createUpdate(
+                    """
+                    INSERT INTO backfill_checkpoints (version, last_cursor_time, last_run_id, completed_at, updated_at)
+                    VALUES (:version, now(), '', now(), now())
+                    ON CONFLICT (version) DO UPDATE SET completed_at = now(), updated_at = now()
+                    """)
+                .bind("version", VERSION)
+                .execute());
+  }
+
+  private String readCheckpointCtid() {
+    return jdbi.withHandle(
+        handle ->
+            handle
+                .createQuery(
+                    "SELECT last_run_id FROM backfill_checkpoints WHERE version = :version")
+                .bind("version", VERSION)
+                .mapTo(String.class)
+                .findOne()
+                .filter(s -> !s.isEmpty())
+                .orElse("(0,0)"));
+  }
+
+  private void saveCheckpointCtid(Handle handle, String lastCtid) {
+    handle
+        .createUpdate(
+            """
+            INSERT INTO backfill_checkpoints (version, last_cursor_time, last_run_id, updated_at)
+            VALUES (:version, '1970-01-01 00:00:00+00', :lastCtid, now())
+            ON CONFLICT (version) DO UPDATE SET last_run_id = EXCLUDED.last_run_id, updated_at = now()
+            """)
+        .bind("version", VERSION)
+        .bind("lastCtid", lastCtid)
+        .execute();
+  }
+
+  private void maybeSleep() throws InterruptedException {
+    long delay = config.getDelayBetweenBatchesMs();
+    if (delay > 0) {
+      Thread.sleep(delay);
+    }
+  }
+}

--- a/api/src/main/java/marquez/jobs/backfill/RunFacetsPartitionBackfillJob.java
+++ b/api/src/main/java/marquez/jobs/backfill/RunFacetsPartitionBackfillJob.java
@@ -5,49 +5,21 @@
 
 package marquez.jobs.backfill;
 
-import java.time.Instant;
 import java.util.List;
 import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
 import marquez.jobs.BackfillConfig;
-import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 
 /**
- * Online cutover for partitioning {@code run_facets} on a large existing database, mirroring what
- * V108 does inline on a small/empty one — but without blocking startup.
- *
- * <p>V108 arms the cutover for a large table: it builds the empty partitioned shadow {@code
- * run_facets_p}, installs an {@code AFTER INSERT} trigger that mirrors every row with {@code
- * created_at >= cutover} into the shadow, and records {@code cutover} in {@code
- * run_facets_partition_state}. This job then, in the background:
- *
- * <ol>
- *   <li><strong>Bulk copy</strong> — copies the historical rows ({@code created_at < cutover}) into
- *       the shadow in ctid-keyset batches, checkpointed in {@code backfill_checkpoints} so a
- *       restart resumes without re-copying. The trigger owns everything at/after the cutover, so
- *       the two sets are disjoint by value: exactly-once, no primary key required.
- *   <li><strong>Verified swap</strong> — once the copy drains, it takes a brief {@code ACCESS
- *       EXCLUSIVE} lock, confirms {@code count(run_facets) == count(run_facets_p)} (both frozen),
- *       and only then atomically renames the shadow into place, restores the FK + view, and drops
- *       the trigger and old table. The old table is the source of truth until this verified swap,
- *       so an interrupted copy or a count mismatch loses nothing — it simply retries.
- * </ol>
- *
- * <p>On a small/empty database V108 already swapped inline (state {@code SWAPPED}); this job then
- * detects the finished state and no-ops.
+ * Online cutover that partitions {@code run_facets} on a large existing database (V108). See {@link
+ * AbstractPartitionCutoverBackfillJob} for the copy + verified-swap mechanics.
  */
-@Slf4j
-public class RunFacetsPartitionBackfillJob implements BackfillJob {
+public class RunFacetsPartitionBackfillJob extends AbstractPartitionCutoverBackfillJob {
 
   public static final String VERSION = "RUN_FACETS_PARTITION_V1";
 
-  private final Jdbi jdbi;
-  private final BackfillConfig config;
-
   public RunFacetsPartitionBackfillJob(@NonNull Jdbi jdbi, @NonNull BackfillConfig config) {
-    this.jdbi = jdbi;
-    this.config = config;
+    super(jdbi, config);
   }
 
   @Override
@@ -56,249 +28,52 @@ public class RunFacetsPartitionBackfillJob implements BackfillJob {
   }
 
   @Override
-  public void run() throws Exception {
-    if (isCompleted()) {
-      log.info("RunFacetsPartitionBackfillJob: already completed — skipping.");
-      return;
-    }
-
-    // Nothing to do unless V108 armed an online cutover on a large table.
-    String state = readState();
-    if (!"DUAL_WRITE".equals(state)) {
-      log.info(
-          "RunFacetsPartitionBackfillJob: state='{}' (not DUAL_WRITE) — run_facets was partitioned"
-              + " inline or is not armed; nothing to do.",
-          state);
-      markCompleted();
-      return;
-    }
-    if (isRunFacetsPartitioned()) {
-      log.info("RunFacetsPartitionBackfillJob: run_facets already partitioned — marking done.");
-      markCompleted();
-      return;
-    }
-
-    Instant cutover = readCutover();
-    log.info(
-        "RunFacetsPartitionBackfillJob: starting online copy of rows created before {}.", cutover);
-
-    long copied = runBulkCopy(cutover);
-    log.info("RunFacetsPartitionBackfillJob: bulk copy drained after {} rows this run.", copied);
-
-    if (Thread.currentThread().isInterrupted()) {
-      log.info("RunFacetsPartitionBackfillJob: interrupted before swap — will resume on restart.");
-      return;
-    }
-
-    performVerifiedSwap();
+  protected String table() {
+    return "run_facets";
   }
 
-  // ---------------------------------------------------------------------------
-  // Bulk copy — ctid keyset, one transaction per batch, checkpointed.
-  // ---------------------------------------------------------------------------
-
-  private long runBulkCopy(Instant cutover) throws InterruptedException {
-    String lastCtid = readCheckpointCtid();
-    long total = 0;
-
-    while (true) {
-      if (Thread.currentThread().isInterrupted()) {
-        throw new InterruptedException("Interrupted during run_facets bulk copy");
-      }
-
-      final String from = lastCtid;
-      List<String> ctids =
-          jdbi.withHandle(
-              handle ->
-                  handle
-                      .createQuery(
-                          // Alias the projection: an unaliased `ctid::text` is output-named `ctid`,
-                          // and ORDER BY would then bind to that TEXT column (lexical order:
-                          // '(0,10)' < '(0,2)') instead of the tid column, corrupting the keyset.
-                          """
-                          SELECT ctid::text AS ctid_text FROM run_facets
-                          WHERE created_at < :cutover AND ctid > :from::tid
-                          ORDER BY ctid
-                          LIMIT :batchSize
-                          """)
-                      .bind("cutover", cutover)
-                      .bind("from", from)
-                      .bind("batchSize", config.getBatchSize())
-                      .mapTo(String.class)
-                      .list());
-
-      if (ctids.isEmpty()) {
-        break;
-      }
-
-      final String batchLast = ctids.get(ctids.size() - 1);
-      jdbi.useTransaction(
-          handle -> {
-            handle
-                .createUpdate(
-                    """
-                    INSERT INTO run_facets_p (
-                        created_at, run_uuid, lineage_event_time, lineage_event_type,
-                        name, facet, namespace)
-                    SELECT o.created_at, o.run_uuid, o.lineage_event_time, o.lineage_event_type,
-                           o.name, o.facet,
-                           COALESCE(o.namespace,
-                                    (SELECT namespace_name FROM runs WHERE uuid = o.run_uuid))
-                    FROM run_facets o
-                    WHERE o.ctid = ANY(:ctids::tid[])
-                    """)
-                .bindArray("ctids", String.class, ctids)
-                .execute();
-            saveCheckpointCtid(handle, batchLast);
-          });
-
-      lastCtid = batchLast;
-      total += ctids.size();
-      maybeSleep();
-    }
-    return total;
+  @Override
+  protected String shadow() {
+    return "run_facets_p";
   }
 
-  // ---------------------------------------------------------------------------
-  // Verified swap — brief ACCESS EXCLUSIVE lock, count parity, atomic rename.
-  // ---------------------------------------------------------------------------
-
-  private void performVerifiedSwap() {
-    jdbi.useTransaction(
-        handle -> {
-          // Freeze writers so old + shadow are static while we verify and swap.
-          handle.execute("LOCK TABLE run_facets IN ACCESS EXCLUSIVE MODE");
-
-          long oldCount = countOf(handle, "run_facets");
-          long shadowCount = countOf(handle, "run_facets_p");
-          if (oldCount != shadowCount) {
-            // Old table is still the source of truth and fully intact. Do NOT swap; abort the
-            // transaction so nothing changes, and leave state=DUAL_WRITE to retry. A persistent
-            // mismatch (e.g. a clock-skew boundary row) is resolved by rebuilding the shadow.
-            throw new IllegalStateException(
-                String.format(
-                    "run_facets swap aborted: count mismatch old=%d shadow=%d — not swapping,"
-                        + " old table preserved. Will retry.",
-                    oldCount, shadowCount));
-          }
-
-          handle.execute("DROP VIEW IF EXISTS run_facets_view");
-          handle.execute("DROP TRIGGER IF EXISTS run_facets_mirror_trg ON run_facets");
-          handle.execute("ALTER TABLE run_facets RENAME TO run_facets_old");
-          handle.execute("ALTER TABLE run_facets_p RENAME TO run_facets");
-          handle.execute(
-              "ALTER TABLE run_facets ADD CONSTRAINT run_facets_run_uuid_fkey"
-                  + " FOREIGN KEY (run_uuid) REFERENCES runs (uuid) ON DELETE CASCADE");
-          handle.execute(
-              "CREATE VIEW run_facets_view AS SELECT created_at, run_uuid, lineage_event_time,"
-                  + " lineage_event_type, name, facet FROM run_facets");
-          handle.execute("DROP TABLE run_facets_old");
-          handle.execute("UPDATE run_facets_partition_state SET state = 'SWAPPED'");
-        });
-    markCompleted();
-    log.info("RunFacetsPartitionBackfillJob: verified swap complete — run_facets is partitioned.");
+  @Override
+  protected String stateTable() {
+    return "run_facets_partition_state";
   }
 
-  private long countOf(Handle handle, String table) {
-    return handle.createQuery("SELECT count(*) FROM " + table).mapTo(Long.class).one();
+  @Override
+  protected String triggerName() {
+    return "run_facets_mirror_trg";
   }
 
-  // ---------------------------------------------------------------------------
-  // State + checkpoint helpers.
-  // ---------------------------------------------------------------------------
-
-  private String readState() {
-    return jdbi.withHandle(
-        handle ->
-            handle
-                .createQuery("SELECT state FROM run_facets_partition_state LIMIT 1")
-                .mapTo(String.class)
-                .findOne()
-                .orElse("NONE"));
+  @Override
+  protected String boundaryColumn() {
+    return "created_at";
   }
 
-  private Instant readCutover() {
-    return jdbi.withHandle(
-        handle ->
-            handle
-                .createQuery("SELECT cutover_at FROM run_facets_partition_state LIMIT 1")
-                .mapTo(Instant.class)
-                .one());
+  @Override
+  protected String insertColumns() {
+    return "created_at, run_uuid, lineage_event_time, lineage_event_type, name, facet, namespace";
   }
 
-  private boolean isRunFacetsPartitioned() {
-    return jdbi.withHandle(
-        handle ->
-            handle
-                .createQuery(
-                    "SELECT EXISTS(SELECT 1 FROM pg_partitioned_table"
-                        + " WHERE partrelid = 'run_facets'::regclass)")
-                .mapTo(Boolean.class)
-                .one());
+  @Override
+  protected String selectExpr() {
+    return "o.created_at, o.run_uuid, o.lineage_event_time, o.lineage_event_type, o.name, o.facet,"
+        + " COALESCE(o.namespace, (SELECT namespace_name FROM runs WHERE uuid = o.run_uuid))";
   }
 
-  private boolean isCompleted() {
-    try {
-      return jdbi.withHandle(
-          handle ->
-              handle
-                  .createQuery(
-                      "SELECT completed_at IS NOT NULL FROM backfill_checkpoints"
-                          + " WHERE version = :version")
-                  .bind("version", VERSION)
-                  .mapTo(Boolean.class)
-                  .findOne()
-                  .orElse(false));
-    } catch (Exception e) {
-      log.warn("RunFacetsPartitionBackfillJob: could not check completed_at — assuming not done.");
-      return false;
-    }
+  @Override
+  protected List<String> preSwapDdl() {
+    return List.of("DROP VIEW IF EXISTS run_facets_view");
   }
 
-  private void markCompleted() {
-    jdbi.useHandle(
-        handle ->
-            handle
-                .createUpdate(
-                    """
-                    INSERT INTO backfill_checkpoints (version, last_cursor_time, last_run_id, completed_at, updated_at)
-                    VALUES (:version, now(), '', now(), now())
-                    ON CONFLICT (version) DO UPDATE SET completed_at = now(), updated_at = now()
-                    """)
-                .bind("version", VERSION)
-                .execute());
-  }
-
-  private String readCheckpointCtid() {
-    return jdbi.withHandle(
-        handle ->
-            handle
-                .createQuery(
-                    "SELECT last_run_id FROM backfill_checkpoints WHERE version = :version")
-                .bind("version", VERSION)
-                .mapTo(String.class)
-                .findOne()
-                .filter(s -> !s.isEmpty())
-                .orElse("(0,0)"));
-  }
-
-  private void saveCheckpointCtid(Handle handle, String lastCtid) {
-    handle
-        .createUpdate(
-            """
-            INSERT INTO backfill_checkpoints (version, last_cursor_time, last_run_id, updated_at)
-            VALUES (:version, '1970-01-01 00:00:00+00', :lastCtid, now())
-            ON CONFLICT (version) DO UPDATE SET last_run_id = EXCLUDED.last_run_id, updated_at = now()
-            """)
-        .bind("version", VERSION)
-        .bind("lastCtid", lastCtid)
-        .execute();
-  }
-
-  private void maybeSleep() throws InterruptedException {
-    long delay = config.getDelayBetweenBatchesMs();
-    if (delay > 0) {
-      Thread.sleep(delay);
-    }
+  @Override
+  protected List<String> postSwapDdl() {
+    return List.of(
+        "ALTER TABLE run_facets ADD CONSTRAINT run_facets_run_uuid_fkey"
+            + " FOREIGN KEY (run_uuid) REFERENCES runs (uuid) ON DELETE CASCADE",
+        "CREATE VIEW run_facets_view AS SELECT created_at, run_uuid, lineage_event_time,"
+            + " lineage_event_type, name, facet FROM run_facets");
   }
 }

--- a/api/src/main/java/marquez/service/DenormalizedLineageService.java
+++ b/api/src/main/java/marquez/service/DenormalizedLineageService.java
@@ -538,8 +538,8 @@ public class DenormalizedLineageService {
             }
 
             // Step 5: Write pre-materialized edges to lineage_edges for BFS-in-Java reads.
-            // ON CONFLICT DO NOTHING ensures each physical edge is written exactly once
-            // regardless of how many runs traverse the same dataset→dataset path.
+            // Each edge is a run↔dataset_version pair (CONSUMES or PRODUCES).
+            // ON CONFLICT DO NOTHING skips duplicate writes if the same run is reprocessed.
             populateLineageEdgesForRun(handle, runUuid);
           });
 
@@ -692,10 +692,11 @@ public class DenormalizedLineageService {
   }
 
   /**
-   * Writes pre-materialized adjacency rows to lineage_edges for BFS-in-Java reads. Called at
-   * COMPLETE/FAIL time only. ON CONFLICT DO NOTHING is intentional: the same logical edge (two
-   * nodes connected by a specific edge type) is stored exactly once regardless of how many runs
-   * traverse it — run_uuid records the first run that established the edge.
+   * Writes pre-materialized run↔dataset_version edges to lineage_edges for BFS-in-Java reads.
+   * Called at COMPLETE/FAIL time only. Each row represents one hop between a run and a
+   * dataset_version (CONSUMES: dataset_version→run; PRODUCES: run→dataset_version). run_uuid is the
+   * run endpoint of the edge. ON CONFLICT DO NOTHING skips re-insertion if the same run reprocesses
+   * the same dataset_version.
    */
   private void populateLineageEdgesForRun(org.jdbi.v3.core.Handle handle, UUID runUuid) {
     log.debug("Populating lineage_edges for run: {}", runUuid);

--- a/api/src/main/java/marquez/service/DenormalizedLineageService.java
+++ b/api/src/main/java/marquez/service/DenormalizedLineageService.java
@@ -692,11 +692,10 @@ public class DenormalizedLineageService {
   }
 
   /**
-   * Writes pre-materialized adjacency rows to lineage_edges for BFS-in-Java reads.
-   * Called at COMPLETE/FAIL time only. ON CONFLICT DO NOTHING is intentional:
-   * the same logical edge (two nodes connected by a specific edge type) is stored
-   * exactly once regardless of how many runs traverse it — run_uuid records the
-   * first run that established the edge.
+   * Writes pre-materialized adjacency rows to lineage_edges for BFS-in-Java reads. Called at
+   * COMPLETE/FAIL time only. ON CONFLICT DO NOTHING is intentional: the same logical edge (two
+   * nodes connected by a specific edge type) is stored exactly once regardless of how many runs
+   * traverse it — run_uuid records the first run that established the edge.
    */
   private void populateLineageEdgesForRun(org.jdbi.v3.core.Handle handle, UUID runUuid) {
     log.debug("Populating lineage_edges for run: {}", runUuid);
@@ -745,14 +744,14 @@ public class DenormalizedLineageService {
         ON CONFLICT (from_node_id, to_node_id, edge_type) DO NOTHING
         """;
 
-    int consumesRows =
-        handle.createUpdate(consumesSql).bind("runUuid", runUuid).execute();
-    int producesRows =
-        handle.createUpdate(producesSql).bind("runUuid", runUuid).execute();
+    int consumesRows = handle.createUpdate(consumesSql).bind("runUuid", runUuid).execute();
+    int producesRows = handle.createUpdate(producesSql).bind("runUuid", runUuid).execute();
 
     log.debug(
         "Populated lineage_edges for run {}: {} CONSUMES edges, {} PRODUCES edges",
-        runUuid, consumesRows, producesRows);
+        runUuid,
+        consumesRows,
+        producesRows);
   }
 
   /** Check if a run is a parent run (has child runs). */

--- a/api/src/main/java/marquez/service/DenormalizedLineageService.java
+++ b/api/src/main/java/marquez/service/DenormalizedLineageService.java
@@ -536,6 +536,11 @@ public class DenormalizedLineageService {
             if (isParentRun(handle, runUuid)) {
               populateRunParentLineageDenormalized(handle, runUuid);
             }
+
+            // Step 5: Write pre-materialized edges to lineage_edges for BFS-in-Java reads.
+            // ON CONFLICT DO NOTHING ensures each physical edge is written exactly once
+            // regardless of how many runs traverse the same dataset→dataset path.
+            populateLineageEdgesForRun(handle, runUuid);
           });
 
       log.info("Successfully populated denormalized lineage tables for run: {}", runUuid);
@@ -684,6 +689,70 @@ public class DenormalizedLineageService {
     int insertedRows = handle.createUpdate(insertQuery).bind("runUuid", runUuid).execute();
     log.debug(
         "Inserted {} rows into run_parent_lineage_denormalized for run: {}", insertedRows, runUuid);
+  }
+
+  /**
+   * Writes pre-materialized adjacency rows to lineage_edges for BFS-in-Java reads.
+   * Called at COMPLETE/FAIL time only. ON CONFLICT DO NOTHING is intentional:
+   * the same logical edge (two nodes connected by a specific edge type) is stored
+   * exactly once regardless of how many runs traverse it — run_uuid records the
+   * first run that established the edge.
+   */
+  private void populateLineageEdgesForRun(org.jdbi.v3.core.Handle handle, UUID runUuid) {
+    log.debug("Populating lineage_edges for run: {}", runUuid);
+
+    // CONSUMES edges: input dataset_version → run
+    String consumesSql =
+        """
+        INSERT INTO lineage_edges (
+            from_node_id, from_type, to_node_id, to_type,
+            edge_type, run_uuid, run_date, created_at
+        )
+        SELECT
+            rim.dataset_version_uuid   AS from_node_id,
+            'dataset_version'          AS from_type,
+            r.uuid                     AS to_node_id,
+            'run'                      AS to_type,
+            'CONSUMES'                 AS edge_type,
+            r.uuid                     AS run_uuid,
+            DATE(COALESCE(r.ended_at, r.started_at, r.created_at)) AS run_date,
+            NOW()                      AS created_at
+        FROM runs r
+        INNER JOIN runs_input_mapping rim ON rim.run_uuid = r.uuid
+        WHERE r.uuid = :runUuid
+        ON CONFLICT (from_node_id, to_node_id, edge_type) DO NOTHING
+        """;
+
+    // PRODUCES edges: run → output dataset_version
+    String producesSql =
+        """
+        INSERT INTO lineage_edges (
+            from_node_id, from_type, to_node_id, to_type,
+            edge_type, run_uuid, run_date, created_at
+        )
+        SELECT
+            r.uuid                     AS from_node_id,
+            'run'                      AS from_type,
+            dv.uuid                    AS to_node_id,
+            'dataset_version'          AS to_type,
+            'PRODUCES'                 AS edge_type,
+            r.uuid                     AS run_uuid,
+            DATE(COALESCE(r.ended_at, r.started_at, r.created_at)) AS run_date,
+            NOW()                      AS created_at
+        FROM runs r
+        INNER JOIN dataset_versions dv ON dv.run_uuid = r.uuid
+        WHERE r.uuid = :runUuid
+        ON CONFLICT (from_node_id, to_node_id, edge_type) DO NOTHING
+        """;
+
+    int consumesRows =
+        handle.createUpdate(consumesSql).bind("runUuid", runUuid).execute();
+    int producesRows =
+        handle.createUpdate(producesSql).bind("runUuid", runUuid).execute();
+
+    log.debug(
+        "Populated lineage_edges for run {}: {} CONSUMES edges, {} PRODUCES edges",
+        runUuid, consumesRows, producesRows);
   }
 
   /** Check if a run is a parent run (has child runs). */

--- a/api/src/main/java/marquez/service/DenormalizedLineageService.java
+++ b/api/src/main/java/marquez/service/DenormalizedLineageService.java
@@ -753,11 +753,64 @@ public class DenormalizedLineageService {
     int consumesRows = handle.createUpdate(consumesSql).bind("runUuid", runUuid).execute();
     int producesRows = handle.createUpdate(producesSql).bind("runUuid", runUuid).execute();
 
+    // Job<->dataset edges for the run's job (job & dataset lineage). run_uuid is NULL (a job edge
+    // has no run); a BFS over these reproduces the "two jobs share any dataset" adjacency. ON
+    // CONFLICT dedupes; edges age out with their run_date partition and are re-written by new runs.
+    String jobConsumesSql =
+        """
+        INSERT INTO lineage_edges (
+            from_node_id, from_type, to_node_id, to_type,
+            edge_type, namespace, run_uuid, run_date, created_at
+        )
+        SELECT DISTINCT
+            dv.dataset_uuid           AS from_node_id,
+            'dataset'                 AS from_type,
+            r.job_uuid                AS to_node_id,
+            'job'                     AS to_type,
+            'CONSUMES'                AS edge_type,
+            r.namespace_name          AS namespace,
+            NULL::uuid                AS run_uuid,
+            DATE(COALESCE(r.ended_at, r.started_at, r.created_at)) AS run_date,
+            NOW()                     AS created_at
+        FROM runs r
+        INNER JOIN runs_input_mapping rim ON rim.run_uuid = r.uuid
+        INNER JOIN dataset_versions dv ON dv.uuid = rim.dataset_version_uuid
+        WHERE r.uuid = :runUuid AND r.job_uuid IS NOT NULL
+        ON CONFLICT (from_node_id, to_node_id, edge_type, run_date, namespace) DO NOTHING
+        """;
+
+    String jobProducesSql =
+        """
+        INSERT INTO lineage_edges (
+            from_node_id, from_type, to_node_id, to_type,
+            edge_type, namespace, run_uuid, run_date, created_at
+        )
+        SELECT DISTINCT
+            r.job_uuid                AS from_node_id,
+            'job'                     AS from_type,
+            dv.dataset_uuid           AS to_node_id,
+            'dataset'                 AS to_type,
+            'PRODUCES'                AS edge_type,
+            r.namespace_name          AS namespace,
+            NULL::uuid                AS run_uuid,
+            DATE(COALESCE(r.ended_at, r.started_at, r.created_at)) AS run_date,
+            NOW()                     AS created_at
+        FROM runs r
+        INNER JOIN dataset_versions dv ON dv.run_uuid = r.uuid
+        WHERE r.uuid = :runUuid AND r.job_uuid IS NOT NULL
+        ON CONFLICT (from_node_id, to_node_id, edge_type, run_date, namespace) DO NOTHING
+        """;
+
+    int jobConsumesRows = handle.createUpdate(jobConsumesSql).bind("runUuid", runUuid).execute();
+    int jobProducesRows = handle.createUpdate(jobProducesSql).bind("runUuid", runUuid).execute();
+
     log.debug(
-        "Populated lineage_edges for run {}: {} CONSUMES edges, {} PRODUCES edges",
+        "Populated lineage_edges for run {}: {} CONSUMES, {} PRODUCES, {} job-CONSUMES, {} job-PRODUCES",
         runUuid,
         consumesRows,
-        producesRows);
+        producesRows,
+        jobConsumesRows,
+        jobProducesRows);
   }
 
   /** Check if a run is a parent run (has child runs). */

--- a/api/src/main/java/marquez/service/DenormalizedLineageService.java
+++ b/api/src/main/java/marquez/service/DenormalizedLineageService.java
@@ -701,12 +701,15 @@ public class DenormalizedLineageService {
   private void populateLineageEdgesForRun(org.jdbi.v3.core.Handle handle, UUID runUuid) {
     log.debug("Populating lineage_edges for run: {}", runUuid);
 
-    // CONSUMES edges: input dataset_version → run
+    // CONSUMES edges: input dataset_version → run.
+    // namespace (the run's namespace) and run_date are part of the PK — both are
+    // functionally determined by the run, so the 5-column ON CONFLICT dedupes
+    // exactly one row per physical edge while feeding the RANGE→HASH partitioning.
     String consumesSql =
         """
         INSERT INTO lineage_edges (
             from_node_id, from_type, to_node_id, to_type,
-            edge_type, run_uuid, run_date, created_at
+            edge_type, namespace, run_uuid, run_date, created_at
         )
         SELECT
             rim.dataset_version_uuid   AS from_node_id,
@@ -714,13 +717,14 @@ public class DenormalizedLineageService {
             r.uuid                     AS to_node_id,
             'run'                      AS to_type,
             'CONSUMES'                 AS edge_type,
+            r.namespace_name           AS namespace,
             r.uuid                     AS run_uuid,
             DATE(COALESCE(r.ended_at, r.started_at, r.created_at)) AS run_date,
             NOW()                      AS created_at
         FROM runs r
         INNER JOIN runs_input_mapping rim ON rim.run_uuid = r.uuid
         WHERE r.uuid = :runUuid
-        ON CONFLICT (from_node_id, to_node_id, edge_type) DO NOTHING
+        ON CONFLICT (from_node_id, to_node_id, edge_type, run_date, namespace) DO NOTHING
         """;
 
     // PRODUCES edges: run → output dataset_version
@@ -728,7 +732,7 @@ public class DenormalizedLineageService {
         """
         INSERT INTO lineage_edges (
             from_node_id, from_type, to_node_id, to_type,
-            edge_type, run_uuid, run_date, created_at
+            edge_type, namespace, run_uuid, run_date, created_at
         )
         SELECT
             r.uuid                     AS from_node_id,
@@ -736,13 +740,14 @@ public class DenormalizedLineageService {
             dv.uuid                    AS to_node_id,
             'dataset_version'          AS to_type,
             'PRODUCES'                 AS edge_type,
+            r.namespace_name           AS namespace,
             r.uuid                     AS run_uuid,
             DATE(COALESCE(r.ended_at, r.started_at, r.created_at)) AS run_date,
             NOW()                      AS created_at
         FROM runs r
         INNER JOIN dataset_versions dv ON dv.run_uuid = r.uuid
         WHERE r.uuid = :runUuid
-        ON CONFLICT (from_node_id, to_node_id, edge_type) DO NOTHING
+        ON CONFLICT (from_node_id, to_node_id, edge_type, run_date, namespace) DO NOTHING
         """;
 
     int consumesRows = handle.createUpdate(consumesSql).bind("runUuid", runUuid).execute();

--- a/api/src/main/java/marquez/service/LineageService.java
+++ b/api/src/main/java/marquez/service/LineageService.java
@@ -64,6 +64,10 @@ public class LineageService extends DelegatingLineageDao {
 
   public record UpstreamRun(JobSummary job, RunSummary run, List<DatasetSummary> inputs) {}
 
+  /** Hard server-side depth caps to prevent runaway recursive CTEs and unbounded responses. */
+  public static final int MAX_DEPTH_V1 = 10;
+  public static final int MAX_DEPTH_V2 = 20;
+
   private final JobDao jobDao;
 
   private final RunDao runDao;
@@ -81,6 +85,7 @@ public class LineageService extends DelegatingLineageDao {
 
   public Lineage lineage(
       NodeId nodeId, int depth, boolean aggregateToParentRun, Set<String> includeFacets) {
+    depth = Math.min(depth, MAX_DEPTH_V1);
     log.debug("Attempting to get lineage for node '{}' with depth '{}'", nodeId.getValue(), depth);
 
     if (nodeId.isRunType() || nodeId.isDatasetVersionType()) {
@@ -199,8 +204,10 @@ public class LineageService extends DelegatingLineageDao {
     log.debug(
         "Attempting to get V2 lineage for node '{}' with depth '{}'", nodeId.getValue(), depth);
 
+    // Run/dataset-version nodes use the same denormalized path as V1 — there is no separate
+    // V2 optimization for these node types yet; route through the shared implementation.
     if (nodeId.isRunType() || nodeId.isDatasetVersionType()) {
-      return lineage(nodeId, depth, aggregateToParentRun, includeFacets);
+      return lineage(nodeId, Math.min(depth, MAX_DEPTH_V2), aggregateToParentRun, includeFacets);
     }
 
     Optional<UUID> optionalUUID = getJobUuidV2(nodeId);
@@ -253,7 +260,8 @@ public class LineageService extends DelegatingLineageDao {
     if (!datasetIds.isEmpty()) {
       datasets.addAll(this.getDatasetDataV2(datasetIds));
       if (datasets.isEmpty()) {
-        datasets.addAll(this.getDatasetData(datasetIds));
+        log.warn("V2 dataset lookup returned empty for {} UUIDs — denorm tables may be lagging behind normalized store",
+            datasetIds.size());
       }
     }
 
@@ -534,7 +542,7 @@ public class LineageService extends DelegatingLineageDao {
                         rd.getOutputDatasetVersions().stream()
                             .map(OutputDatasetVersion::getDatasetVersionId)))
             .collect(Collectors.toSet());
-    log.info("DatasetVersionIds found in run data: {}", datasetVersionIds);
+    log.debug("DatasetVersionIds found in run data: {}", datasetVersionIds.size());
 
     Set<DatasetVersionData> datasetVersions = new HashSet<>();
 
@@ -543,7 +551,7 @@ public class LineageService extends DelegatingLineageDao {
             datasetVersionIds.stream()
                 .map(DatasetVersionId::getVersion)
                 .collect(Collectors.toSet())));
-    log.debug("Retrieved dataset data: {}", datasetVersions);
+    log.debug("Retrieved {} dataset versions", datasetVersions.size());
 
     Map<UUID, DatasetVersionData> datasetVersionById =
         datasetVersions.stream()
@@ -583,11 +591,6 @@ public class LineageService extends DelegatingLineageDao {
           ds -> dsOutputToRun.computeIfAbsent(ds, e -> new HashSet<>()).add(data.getUuid()));
 
       NodeId origin = NodeId.of(RunId.of(data.getUuid()));
-      log.info(
-          "dsInputToRun: {}, dsOutputToRun: {}, runDataMap: {}",
-          dsInputToRun,
-          dsOutputToRun,
-          runDataMap);
       Node node =
           new Node(
               origin,

--- a/api/src/main/java/marquez/service/LineageService.java
+++ b/api/src/main/java/marquez/service/LineageService.java
@@ -86,7 +86,11 @@ public class LineageService extends DelegatingLineageDao {
 
   public Lineage lineage(
       NodeId nodeId, int depth, boolean aggregateToParentRun, Set<String> includeFacets) {
-    depth = Math.min(depth, MAX_DEPTH_V1);
+    return lineageImpl(nodeId, Math.min(depth, MAX_DEPTH_V1), aggregateToParentRun, includeFacets);
+  }
+
+  private Lineage lineageImpl(
+      NodeId nodeId, int depth, boolean aggregateToParentRun, Set<String> includeFacets) {
     log.debug("Attempting to get lineage for node '{}' with depth '{}'", nodeId.getValue(), depth);
 
     if (nodeId.isRunType() || nodeId.isDatasetVersionType()) {
@@ -205,10 +209,11 @@ public class LineageService extends DelegatingLineageDao {
     log.debug(
         "Attempting to get V2 lineage for node '{}' with depth '{}'", nodeId.getValue(), depth);
 
-    // Run/dataset-version nodes use the same denormalized path as V1 — there is no separate
-    // V2 optimization for these node types yet; route through the shared implementation.
+    // Run/dataset-version nodes use the same denormalized path as V1 — route through the shared
+    // implementation but cap to MAX_DEPTH_V2 (not V1) so V2 callers get the higher depth limit.
     if (nodeId.isRunType() || nodeId.isDatasetVersionType()) {
-      return lineage(nodeId, Math.min(depth, MAX_DEPTH_V2), aggregateToParentRun, includeFacets);
+      return lineageImpl(
+          nodeId, Math.min(depth, MAX_DEPTH_V2), aggregateToParentRun, includeFacets);
     }
 
     Optional<UUID> optionalUUID = getJobUuidV2(nodeId);

--- a/api/src/main/java/marquez/service/LineageService.java
+++ b/api/src/main/java/marquez/service/LineageService.java
@@ -66,6 +66,7 @@ public class LineageService extends DelegatingLineageDao {
 
   /** Hard server-side depth caps to prevent runaway recursive CTEs and unbounded responses. */
   public static final int MAX_DEPTH_V1 = 10;
+
   public static final int MAX_DEPTH_V2 = 20;
 
   private final JobDao jobDao;
@@ -260,7 +261,8 @@ public class LineageService extends DelegatingLineageDao {
     if (!datasetIds.isEmpty()) {
       datasets.addAll(this.getDatasetDataV2(datasetIds));
       if (datasets.isEmpty()) {
-        log.warn("V2 dataset lookup returned empty for {} UUIDs — denorm tables may be lagging behind normalized store",
+        log.warn(
+            "V2 dataset lookup returned empty for {} UUIDs — denorm tables may be lagging behind normalized store",
             datasetIds.size());
       }
     }

--- a/api/src/main/java/marquez/service/LineageService.java
+++ b/api/src/main/java/marquez/service/LineageService.java
@@ -127,6 +127,42 @@ public class LineageService extends DelegatingLineageDao {
     return visited;
   }
 
+  /**
+   * Breadth-first traversal of the job<->dataset edges in {@code lineage_edges}, returning every
+   * job reachable within {@code depth} job-to-job hops of the seeds (inclusive). Two jobs are
+   * adjacent when they share ANY dataset (input or output) — the same adjacency the job-lineage
+   * recursive CTE computes via {@code array_cat(inputs,outputs) && array_cat(inputs,outputs)}. Each
+   * hop expands job → all its datasets (outputs via PRODUCES, inputs via CONSUMES) → all jobs
+   * touching those datasets (producers + consumers). Reuses the run-path edge queries; the
+   * job/dataset UUID space is disjoint from the run/dataset_version space so there is no
+   * cross-family contamination.
+   */
+  Set<UUID> traverseJobLineageEdges(
+      Set<UUID> seedJobIds, int depth, String minDate, String maxDate) {
+    Set<UUID> visited = new HashSet<>(seedJobIds);
+    Set<UUID> frontier = new HashSet<>(seedJobIds);
+    for (int level = 0; level < depth && !frontier.isEmpty(); level++) {
+      // Datasets touched by the frontier jobs: outputs (job --PRODUCES--> dataset) and inputs
+      // (dataset --CONSUMES--> job).
+      Set<UUID> datasets = new HashSet<>();
+      datasets.addAll(findLineageEdgeTargets(frontier, "PRODUCES", minDate, maxDate));
+      datasets.addAll(findLineageEdgeSources(frontier, "CONSUMES", minDate, maxDate));
+
+      Set<UUID> next = new HashSet<>();
+      if (!datasets.isEmpty()) {
+        // Jobs touching those datasets: producers (job --PRODUCES--> dataset) and consumers
+        // (dataset --CONSUMES--> job).
+        next.addAll(findLineageEdgeSources(datasets, "PRODUCES", minDate, maxDate));
+        next.addAll(findLineageEdgeTargets(datasets, "CONSUMES", minDate, maxDate));
+      }
+
+      next.removeAll(visited);
+      visited.addAll(next);
+      frontier = next;
+    }
+    return visited;
+  }
+
   // TODO make input parameters easily extendable if adding more options like 'withJobFacets'
   public Lineage lineage(NodeId nodeId, int depth, boolean aggregateToParentRun) {
     return lineage(nodeId, depth, aggregateToParentRun, null);
@@ -209,7 +245,16 @@ public class LineageService extends DelegatingLineageDao {
       }
       UUID job = optionalUUID.get();
       log.debug("Attempting to get lineage for job '{}'", job);
-      Set<JobData> jobData = getLineage(Collections.singleton(job), depth);
+      Set<JobData> jobData;
+      if (useEdgeBfs) {
+        // BFS over the job<->dataset edges resolves the full reachable job set; hydrate it at
+        // depth 0 so the emitted graph matches the recursive-CTE path. Job lineage is not
+        // date-bounded, so no run_date pruning predicate is passed.
+        Set<UUID> reachableJobs = traverseJobLineageEdges(Set.of(job), depth, null, null);
+        jobData = getLineage(reachableJobs, 0);
+      } else {
+        jobData = getLineage(Collections.singleton(job), depth);
+      }
 
       // Ensure job data is not empty, an empty set cannot be passed to LineageDao.getCurrentRuns()
       // or
@@ -301,7 +346,17 @@ public class LineageService extends DelegatingLineageDao {
     String maxDate =
         dateRange != null && dateRange.maxDate() != null ? dateRange.maxDate().toString() : null;
 
-    Set<JobData> jobData = getLineageV2(Collections.singleton(job), depth, minDate, maxDate);
+    Set<JobData> jobData;
+    if (useEdgeBfs) {
+      // BFS over the job<->dataset edges resolves the full reachable job set; hydrate at depth 0
+      // so the emitted graph matches the recursive-CTE path. Job edges are dated by the job
+      // version's made_current_at (not run time), so no run_date pruning predicate is passed to
+      // the traversal; the run-derived date range still prunes the denormalized hydration reads.
+      Set<UUID> reachableJobs = traverseJobLineageEdges(Set.of(job), depth, null, null);
+      jobData = getLineageV2(reachableJobs, 0, minDate, maxDate);
+    } else {
+      jobData = getLineageV2(Collections.singleton(job), depth, minDate, maxDate);
+    }
     if (jobData.isEmpty()) {
       log.warn(
           "Failed to get V2 lineage for job '{}' associated with node '{}', returning orphan graph...",

--- a/api/src/main/java/marquez/service/LineageService.java
+++ b/api/src/main/java/marquez/service/LineageService.java
@@ -73,10 +73,58 @@ public class LineageService extends DelegatingLineageDao {
 
   private final RunDao runDao;
 
+  /**
+   * When true, run/dataset-version lineage reads traverse the pre-materialized {@code
+   * lineage_edges} adjacency table (BFS in Java) instead of the recursive CTE. Default false — the
+   * CTE path is unchanged until parity is proven. Toggled via env {@code
+   * MARQUEZ_LINEAGE_USE_EDGE_BFS}.
+   */
+  private final boolean useEdgeBfs;
+
   public LineageService(LineageDao delegate, JobDao jobDao, RunDao runDao) {
+    this(delegate, jobDao, runDao, false);
+  }
+
+  public LineageService(LineageDao delegate, JobDao jobDao, RunDao runDao, boolean useEdgeBfs) {
     super(delegate);
     this.jobDao = jobDao;
     this.runDao = runDao;
+    this.useEdgeBfs = useEdgeBfs;
+  }
+
+  /**
+   * Breadth-first traversal of the {@code lineage_edges} adjacency table, returning every run
+   * reachable within {@code depth} run-to-run hops of the seeds (inclusive). Each CTE-style run hop
+   * is two edge hops (run→dataset_version→run); both directions are followed so the result set is
+   * identical to the recursive CTE's {@code io.input_version = l.output_version OR
+   * io.output_version = l.input_version} adjacency. The {@code minDate}/{@code maxDate} bounds
+   * match the CTE's partition-pruning predicate and prune the RANGE(run_date)→HASH(namespace)
+   * partitions.
+   */
+  Set<UUID> traverseRunLineageEdges(
+      Set<UUID> seedRunIds, int depth, String minDate, String maxDate) {
+    Set<UUID> visited = new HashSet<>(seedRunIds);
+    Set<UUID> frontier = new HashSet<>(seedRunIds);
+    for (int level = 0; level < depth && !frontier.isEmpty(); level++) {
+      Set<UUID> next = new HashSet<>();
+
+      // Downstream: run --PRODUCES--> dataset_version --CONSUMES--> run'
+      Set<UUID> producedVersions = findLineageEdgeTargets(frontier, "PRODUCES", minDate, maxDate);
+      if (!producedVersions.isEmpty()) {
+        next.addAll(findLineageEdgeTargets(producedVersions, "CONSUMES", minDate, maxDate));
+      }
+
+      // Upstream: run' --PRODUCES--> dataset_version --CONSUMES--> run
+      Set<UUID> consumedVersions = findLineageEdgeSources(frontier, "CONSUMES", minDate, maxDate);
+      if (!consumedVersions.isEmpty()) {
+        next.addAll(findLineageEdgeSources(consumedVersions, "PRODUCES", minDate, maxDate));
+      }
+
+      next.removeAll(visited);
+      visited.addAll(next);
+      frontier = next;
+    }
+    return visited;
   }
 
   // TODO make input parameters easily extendable if adding more options like 'withJobFacets'
@@ -124,6 +172,15 @@ public class LineageService extends DelegatingLineageDao {
           runData = getParentRunLineageWithFacets(runIds, depth, includeFacets, minDate, maxDate);
         } else {
           runData = getParentRunLineage(runIds, depth, minDate, maxDate);
+        }
+      } else if (useEdgeBfs) {
+        // BFS over lineage_edges resolves the full reachable run set; hydrate it at depth 0 (no
+        // further recursion) so the emitted graph is identical to the recursive-CTE path.
+        Set<UUID> reachableRuns = traverseRunLineageEdges(runIds, depth, minDate, maxDate);
+        if (includeFacets != null && !includeFacets.isEmpty()) {
+          runData = getRunLineageWithFacets(reachableRuns, 0, includeFacets, minDate, maxDate);
+        } else {
+          runData = getRunLineage(reachableRuns, 0, minDate, maxDate);
         }
       } else {
         if (includeFacets != null && !includeFacets.isEmpty()) {

--- a/api/src/main/java/marquez/service/OpenLineageService.java
+++ b/api/src/main/java/marquez/service/OpenLineageService.java
@@ -318,8 +318,12 @@ public class OpenLineageService extends DelegatingDaos.DelegatingOpenLineageDao 
                         String eventTypeUpper = event.getEventType() != null
                             ? event.getEventType().toUpperCase()
                             : "OTHER";
+                        // OpenLineage emits ABORT (not ABORTED); accept both so aborted
+                        // runs are recognized as terminal. COMPLETE/FAIL already match the
+                        // OpenLineage event-type vocabulary.
                         boolean isTerminal = eventTypeUpper.equals("COMPLETE")
                             || eventTypeUpper.equals("FAIL")
+                            || eventTypeUpper.equals("ABORT")
                             || eventTypeUpper.equals("ABORTED");
                         boolean hasDatasets = !datasetUuids.isEmpty();
 
@@ -344,6 +348,7 @@ public class OpenLineageService extends DelegatingDaos.DelegatingOpenLineageDao 
                     String eventType = event.getEventType().toUpperCase();
                     if (eventType.equals("COMPLETE")
                         || eventType.equals("FAIL")
+                        || eventType.equals("ABORT")
                         || eventType.equals("ABORTED")) {
                       CompletableFuture.runAsync(
                           withSentry(

--- a/api/src/main/java/marquez/service/OpenLineageService.java
+++ b/api/src/main/java/marquez/service/OpenLineageService.java
@@ -296,7 +296,8 @@ public class OpenLineageService extends DelegatingDaos.DelegatingOpenLineageDao 
 
                     // Only update denormalized metadata tables when the event carries new dataset
                     // lineage or is a terminal state. Spark emits ~200 RUNNING events per job that
-                    // are pure metric heartbeats with no lineage change; writing those 200x generates
+                    // are pure metric heartbeats with no lineage change; writing those 200x
+                    // generates
                     // 200x the IOPS with no benefit to the read path.
                     if (update.getNamespace() != null) {
                       try {
@@ -315,16 +316,18 @@ public class OpenLineageService extends DelegatingDaos.DelegatingOpenLineageDao 
                               .forEach(ds -> datasetUuids.add(ds.getDatasetRow().getUuid()));
                         }
 
-                        String eventTypeUpper = event.getEventType() != null
-                            ? event.getEventType().toUpperCase()
-                            : "OTHER";
+                        String eventTypeUpper =
+                            event.getEventType() != null
+                                ? event.getEventType().toUpperCase()
+                                : "OTHER";
                         // OpenLineage emits ABORT (not ABORTED); accept both so aborted
                         // runs are recognized as terminal. COMPLETE/FAIL already match the
                         // OpenLineage event-type vocabulary.
-                        boolean isTerminal = eventTypeUpper.equals("COMPLETE")
-                            || eventTypeUpper.equals("FAIL")
-                            || eventTypeUpper.equals("ABORT")
-                            || eventTypeUpper.equals("ABORTED");
+                        boolean isTerminal =
+                            eventTypeUpper.equals("COMPLETE")
+                                || eventTypeUpper.equals("FAIL")
+                                || eventTypeUpper.equals("ABORT")
+                                || eventTypeUpper.equals("ABORTED");
                         boolean hasDatasets = !datasetUuids.isEmpty();
 
                         // Write denorm entities only on START (to register the job), on events
@@ -333,8 +336,10 @@ public class OpenLineageService extends DelegatingDaos.DelegatingOpenLineageDao 
                           denormalizedLineageService.populateDenormalizedEntitiesForEvent(
                               update.getNamespace().getUuid(), jobUuid, datasetUuids);
                         } else {
-                          log.debug("Skipping denorm update for non-lineage-changing event type={} run={}",
-                              eventTypeUpper, runUuid);
+                          log.debug(
+                              "Skipping denorm update for non-lineage-changing event type={} run={}",
+                              eventTypeUpper,
+                              runUuid);
                         }
                       } catch (Exception e) {
                         log.error(

--- a/api/src/main/java/marquez/service/OpenLineageService.java
+++ b/api/src/main/java/marquez/service/OpenLineageService.java
@@ -288,11 +288,12 @@ public class OpenLineageService extends DelegatingDaos.DelegatingOpenLineageDao 
                     buildJobInputUpdate(update).ifPresent(runService::notify);
                     buildRunTransition(update).ifPresent(runService::notify);
 
-                    // Trigger denormalized entity population for ALL events to keep metadata
-                    // updated
+                    // Only update denormalized metadata tables when the event carries new dataset
+                    // lineage or is a terminal state. Spark emits ~200 RUNNING events per job that
+                    // are pure metric heartbeats with no lineage change; writing those 200x generates
+                    // 200x the IOPS with no benefit to the read path.
                     if (update.getNamespace() != null) {
                       try {
-                        // Extract specific entity UUIDs from the event
                         UUID jobUuid = update.getJob() != null ? update.getJob().getUuid() : null;
                         java.util.List<UUID> datasetUuids = new java.util.ArrayList<>();
                         if (update.getInputs() != null && update.getInputs().isPresent()) {
@@ -308,9 +309,23 @@ public class OpenLineageService extends DelegatingDaos.DelegatingOpenLineageDao 
                               .forEach(ds -> datasetUuids.add(ds.getDatasetRow().getUuid()));
                         }
 
-                        // Incrementally update only affected entities (not entire namespace)
-                        denormalizedLineageService.populateDenormalizedEntitiesForEvent(
-                            update.getNamespace().getUuid(), jobUuid, datasetUuids);
+                        String eventTypeUpper = event.getEventType() != null
+                            ? event.getEventType().toUpperCase()
+                            : "OTHER";
+                        boolean isTerminal = eventTypeUpper.equals("COMPLETE")
+                            || eventTypeUpper.equals("FAIL")
+                            || eventTypeUpper.equals("ABORTED");
+                        boolean hasDatasets = !datasetUuids.isEmpty();
+
+                        // Write denorm entities only on START (to register the job), on events
+                        // that carry new datasets, or on terminal events.
+                        if (isTerminal || hasDatasets || eventTypeUpper.equals("START")) {
+                          denormalizedLineageService.populateDenormalizedEntitiesForEvent(
+                              update.getNamespace().getUuid(), jobUuid, datasetUuids);
+                        } else {
+                          log.debug("Skipping denorm update for non-lineage-changing event type={} run={}",
+                              eventTypeUpper, runUuid);
+                        }
                       } catch (Exception e) {
                         log.error(
                             "Failed to populate denormalized entities for namespace: {}",

--- a/api/src/main/java/marquez/service/OpenLineageService.java
+++ b/api/src/main/java/marquez/service/OpenLineageService.java
@@ -252,6 +252,12 @@ public class OpenLineageService extends DelegatingDaos.DelegatingOpenLineageDao 
   }
 
   public CompletableFuture<Void> createAsync(LineageEvent event) {
+    if (event.getRun() == null) {
+      log.warn(
+          "Received LineageEvent with null run field — event skipped. eventType={}",
+          event.getEventType());
+      return CompletableFuture.completedFuture(null);
+    }
     UUID runUuid = runUuidFromEvent(event.getRun());
     CompletableFuture<Void> openLineage =
         CompletableFuture.runAsync(

--- a/api/src/main/java/marquez/service/PartitionManagementService.java
+++ b/api/src/main/java/marquez/service/PartitionManagementService.java
@@ -29,6 +29,23 @@ public class PartitionManagementService {
 
   private static final Logger log = LoggerFactory.getLogger(PartitionManagementService.class);
 
+  /**
+   * Composite RANGE(date)->HASH(namespace) tables (V107 lineage_edges, V108 run_facets). These are
+   * managed by the V110 helpers, not the single-level create_monthly_partition/drop_old_partitions.
+   *
+   * <p>{@code partitionPrefix} differs from {@code parentTable} for run_facets: it was partitioned
+   * via shadow-table swap, so its monthly partitions keep the {@code _p} shadow prefix
+   * (run_facets_p_y2026m01) even though the parent is now {@code run_facets}. {@code
+   * retentionMonths} follows the design doc: run_facets 12 months, lineage_edges 24 months.
+   */
+  private record CompositePartition(
+      String parentTable, String partitionPrefix, int hashModulus, int retentionMonths) {}
+
+  private static final List<CompositePartition> COMPOSITE_PARTITIONS =
+      List.of(
+          new CompositePartition("lineage_edges", "lineage_edges", 8, 24),
+          new CompositePartition("run_facets", "run_facets_p", 8, 12));
+
   private final Jdbi jdbi;
   private final int monthsAhead;
   private final int retentionMonths;
@@ -59,6 +76,37 @@ public class PartitionManagementService {
         });
   }
 
+  /**
+   * Creates the composite RANGE->HASH monthly subtree for the lineage_edges / run_facets tables for
+   * the given date's month. Kept separate from {@link #ensurePartitionExists(LocalDate)} because
+   * the latter is also invoked from historical Flyway migrations (e.g. V86) that run before
+   * V107/V108 created these tables and before V110 created the helper functions — this method must
+   * only be called at runtime (after all migrations), e.g. by {@code PartitionManagementJob}.
+   */
+  public void ensureCompositePartitionExists(LocalDate date) {
+    LocalDate firstOfMonth = date.withDayOfMonth(1);
+    jdbi.useHandle(
+        handle -> {
+          for (CompositePartition cp : COMPOSITE_PARTITIONS) {
+            handle.execute(
+                "SELECT create_monthly_hash_partition(?, ?, ?::date, ?)",
+                cp.parentTable(),
+                cp.partitionPrefix(),
+                firstOfMonth,
+                cp.hashModulus());
+          }
+        });
+  }
+
+  /**
+   * Creates composite RANGE->HASH partitions for the next N months starting from the given date.
+   */
+  public void createCompositePartitionsForPeriod(LocalDate startDate, int months) {
+    for (int i = 0; i < months; i++) {
+      ensureCompositePartitionExists(startDate.plusMonths(i));
+    }
+  }
+
   /** Creates partitions for the next N months starting from the given date. */
   public void createPartitionsForPeriod(LocalDate startDate, int months) {
     log.info("Creating partitions for {} months starting from {}", months, startDate);
@@ -87,6 +135,29 @@ public class PartitionManagementService {
           // Clean up run_parent_lineage_denormalized partitions
           handle.execute(
               "SELECT drop_old_partitions('run_parent_lineage_denormalized', ?)", retentionMonths);
+        });
+
+    cleanupOldCompositePartitions();
+  }
+
+  /**
+   * Drops monthly partitions of the composite RANGE->HASH tables that fall outside each table's
+   * retention window (DROP ... CASCADE removes the month's hash sub-partitions with it). The
+   * DEFAULT partition and any month within retention are preserved.
+   */
+  public void cleanupOldCompositePartitions() {
+    jdbi.useHandle(
+        handle -> {
+          for (CompositePartition cp : COMPOSITE_PARTITIONS) {
+            log.info(
+                "Dropping {} partitions older than {} months",
+                cp.parentTable(),
+                cp.retentionMonths());
+            handle.execute(
+                "SELECT drop_old_hash_partitions(?::regclass, ?)",
+                cp.parentTable(),
+                cp.retentionMonths());
+          }
         });
   }
 

--- a/api/src/main/java/marquez/service/PartitionManagementService.java
+++ b/api/src/main/java/marquez/service/PartitionManagementService.java
@@ -44,7 +44,8 @@ public class PartitionManagementService {
   private static final List<CompositePartition> COMPOSITE_PARTITIONS =
       List.of(
           new CompositePartition("lineage_edges", "lineage_edges", 8, 24),
-          new CompositePartition("run_facets", "run_facets_p", 8, 12));
+          new CompositePartition("run_facets", "run_facets_p", 8, 12),
+          new CompositePartition("dataset_facets", "dataset_facets_p", 8, 12));
 
   private final Jdbi jdbi;
   private final int monthsAhead;

--- a/api/src/main/java/marquez/service/PartitionManagementService.java
+++ b/api/src/main/java/marquez/service/PartitionManagementService.java
@@ -88,6 +88,11 @@ public class PartitionManagementService {
     jdbi.useHandle(
         handle -> {
           for (CompositePartition cp : COMPOSITE_PARTITIONS) {
+            // A composite table may not be partitioned yet: on a large install run_facets stays a
+            // plain table until RUN_FACETS_PARTITION_V1 performs the swap. Skip until then.
+            if (!isPartitioned(handle, cp.parentTable())) {
+              continue;
+            }
             handle.execute(
                 "SELECT create_monthly_hash_partition(?, ?, ?::date, ?)",
                 cp.parentTable(),
@@ -96,6 +101,15 @@ public class PartitionManagementService {
                 cp.hashModulus());
           }
         });
+  }
+
+  private boolean isPartitioned(org.jdbi.v3.core.Handle handle, String table) {
+    return handle
+        .createQuery(
+            "SELECT EXISTS(SELECT 1 FROM pg_partitioned_table WHERE partrelid = to_regclass(:t))")
+        .bind("t", table)
+        .mapTo(Boolean.class)
+        .one();
   }
 
   /**
@@ -149,6 +163,9 @@ public class PartitionManagementService {
     jdbi.useHandle(
         handle -> {
           for (CompositePartition cp : COMPOSITE_PARTITIONS) {
+            if (!isPartitioned(handle, cp.parentTable())) {
+              continue;
+            }
             log.info(
                 "Dropping {} partitions older than {} months",
                 cp.parentTable(),

--- a/api/src/main/java/marquez/service/PartitionManagementService.java
+++ b/api/src/main/java/marquez/service/PartitionManagementService.java
@@ -39,13 +39,18 @@ public class PartitionManagementService {
    * retentionMonths} follows the design doc: run_facets 12 months, lineage_edges 24 months.
    */
   private record CompositePartition(
-      String parentTable, String partitionPrefix, int hashModulus, int retentionMonths) {}
+      String parentTable,
+      String partitionPrefix,
+      String hashColumn,
+      int hashModulus,
+      int retentionMonths) {}
 
   private static final List<CompositePartition> COMPOSITE_PARTITIONS =
       List.of(
-          new CompositePartition("lineage_edges", "lineage_edges", 8, 24),
-          new CompositePartition("run_facets", "run_facets_p", 8, 12),
-          new CompositePartition("dataset_facets", "dataset_facets_p", 8, 12));
+          new CompositePartition("lineage_edges", "lineage_edges", "namespace", 8, 24),
+          new CompositePartition("run_facets", "run_facets_p", "namespace", 8, 12),
+          new CompositePartition("dataset_facets", "dataset_facets_p", "namespace", 8, 12),
+          new CompositePartition("lineage_events", "lineage_events_p", "job_namespace", 8, 24));
 
   private final Jdbi jdbi;
   private final int monthsAhead;
@@ -95,11 +100,12 @@ public class PartitionManagementService {
               continue;
             }
             handle.execute(
-                "SELECT create_monthly_hash_partition(?, ?, ?::date, ?)",
+                "SELECT create_monthly_hash_partition(?, ?, ?::date, ?, ?)",
                 cp.parentTable(),
                 cp.partitionPrefix(),
                 firstOfMonth,
-                cp.hashModulus());
+                cp.hashModulus(),
+                cp.hashColumn());
           }
         });
   }

--- a/api/src/main/resources/marquez/db/migration/V106__add_default_partitions_and_performance_indexes.sql
+++ b/api/src/main/resources/marquez/db/migration/V106__add_default_partitions_and_performance_indexes.sql
@@ -13,6 +13,11 @@
 --   d) job_versions_io_mapping composite — V1 BFS CTE scans entire table
 --   e) run_lineage_denormalized version pair — recursive CTE traversal join
 --
+-- Note: CREATE INDEX without CONCURRENTLY is required for Flyway-managed migrations.
+-- Flyway wraps each migration in a transaction; CONCURRENTLY is forbidden inside
+-- transactions. For production systems with large existing tables, these can be
+-- recreated with CONCURRENTLY after deployment:
+--   DROP INDEX <name>; CREATE INDEX CONCURRENTLY <name> ON <table> (...);
 -- All CREATE INDEX use IF NOT EXISTS so this migration is safe to re-run.
 
 -- ============================================================
@@ -31,23 +36,23 @@ CREATE TABLE IF NOT EXISTS run_parent_lineage_denormalized_default
 
 -- (a) Fast child-run existence check used by hasChildRuns()
 --     Query: SELECT EXISTS (SELECT 1 FROM runs WHERE parent_run_uuid IN (...))
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_runs_parent_run_uuid
+CREATE INDEX IF NOT EXISTS idx_runs_parent_run_uuid
     ON runs (parent_run_uuid)
     WHERE parent_run_uuid IS NOT NULL;
 
 -- (b) getUpstreamRuns() initial case: LEFT JOIN runs_input_mapping ON run_uuid = r.uuid
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_runs_input_mapping_run_uuid
+CREATE INDEX IF NOT EXISTS idx_runs_input_mapping_run_uuid
     ON runs_input_mapping (run_uuid);
 
 -- (c) getUpstreamRuns() recursive case: LEFT JOIN dataset_versions ON dv.uuid = rim.dataset_version_uuid
 --     AND joining back via dv.run_uuid for the next recursion level
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_dataset_versions_run_uuid
+CREATE INDEX IF NOT EXISTS idx_dataset_versions_run_uuid
     ON dataset_versions (run_uuid)
     WHERE run_uuid IS NOT NULL;
 
 -- (d) V1 job lineage BFS: WHERE is_current_job_version = TRUE (partial index already exists
 --     on job_uuid; this adds the dataset_uuid for covering the io_type filter)
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_jvio_current_job_dataset
+CREATE INDEX IF NOT EXISTS idx_jvio_current_job_dataset
     ON job_versions_io_mapping (job_uuid, dataset_uuid, io_type)
     WHERE is_current_job_version = TRUE;
 
@@ -55,18 +60,18 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_jvio_current_job_dataset
 --     (io.input_version_uuid = l.output_version_uuid): already exists as idx_run_lineage_denorm_input_version
 --     (io.output_version_uuid = l.input_version_uuid): already exists as idx_run_lineage_denorm_output_version
 --     Add covering composite for the most selective recursive join pattern:
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_run_lineage_denorm_out_to_in
+CREATE INDEX IF NOT EXISTS idx_run_lineage_denorm_out_to_in
     ON run_lineage_denormalized (output_version_uuid, input_version_uuid, run_uuid)
     WHERE output_version_uuid IS NOT NULL;
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_run_lineage_denorm_in_to_out
+CREATE INDEX IF NOT EXISTS idx_run_lineage_denorm_in_to_out
     ON run_lineage_denormalized (input_version_uuid, output_version_uuid, run_uuid)
     WHERE input_version_uuid IS NOT NULL;
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_run_parent_lineage_denorm_out_to_in
+CREATE INDEX IF NOT EXISTS idx_run_parent_lineage_denorm_out_to_in
     ON run_parent_lineage_denormalized (output_version_uuid, input_version_uuid, run_uuid)
     WHERE output_version_uuid IS NOT NULL;
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_run_parent_lineage_denorm_in_to_out
+CREATE INDEX IF NOT EXISTS idx_run_parent_lineage_denorm_in_to_out
     ON run_parent_lineage_denormalized (input_version_uuid, output_version_uuid, run_uuid)
     WHERE input_version_uuid IS NOT NULL;

--- a/api/src/main/resources/marquez/db/migration/V106__add_default_partitions_and_performance_indexes.sql
+++ b/api/src/main/resources/marquez/db/migration/V106__add_default_partitions_and_performance_indexes.sql
@@ -1,0 +1,72 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- V106: Safety-net DEFAULT partitions + missing indexes for read/write hotspots
+--
+-- PART 1 — DEFAULT partitions
+--   Prevent hard "no partition found" errors if the PartitionManagementJob misses a month.
+--   Rows landing here trigger the monitoring query (see design doc) to alert on-call.
+--
+-- PART 2 — Missing performance indexes
+--   Five indexes identified as missing by the mesh lineage performance review:
+--   a) runs.parent_run_uuid — hasChildRuns() currently seq-scans millions of rows
+--   b) runs_input_mapping.run_uuid — getUpstreamRuns() base case missing index
+--   c) dataset_versions.run_uuid — getUpstreamRuns() LEFT JOIN missing index
+--   d) job_versions_io_mapping composite — V1 BFS CTE scans entire table
+--   e) run_lineage_denormalized version pair — recursive CTE traversal join
+--
+-- All CREATE INDEX use IF NOT EXISTS so this migration is safe to re-run.
+
+-- ============================================================
+-- PART 1: DEFAULT partitions as safety nets
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS run_lineage_denormalized_default
+    PARTITION OF run_lineage_denormalized DEFAULT;
+
+CREATE TABLE IF NOT EXISTS run_parent_lineage_denormalized_default
+    PARTITION OF run_parent_lineage_denormalized DEFAULT;
+
+-- ============================================================
+-- PART 2: Missing indexes
+-- ============================================================
+
+-- (a) Fast child-run existence check used by hasChildRuns()
+--     Query: SELECT EXISTS (SELECT 1 FROM runs WHERE parent_run_uuid IN (...))
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_runs_parent_run_uuid
+    ON runs (parent_run_uuid)
+    WHERE parent_run_uuid IS NOT NULL;
+
+-- (b) getUpstreamRuns() initial case: LEFT JOIN runs_input_mapping ON run_uuid = r.uuid
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_runs_input_mapping_run_uuid
+    ON runs_input_mapping (run_uuid);
+
+-- (c) getUpstreamRuns() recursive case: LEFT JOIN dataset_versions ON dv.uuid = rim.dataset_version_uuid
+--     AND joining back via dv.run_uuid for the next recursion level
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_dataset_versions_run_uuid
+    ON dataset_versions (run_uuid)
+    WHERE run_uuid IS NOT NULL;
+
+-- (d) V1 job lineage BFS: WHERE is_current_job_version = TRUE (partial index already exists
+--     on job_uuid; this adds the dataset_uuid for covering the io_type filter)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_jvio_current_job_dataset
+    ON job_versions_io_mapping (job_uuid, dataset_uuid, io_type)
+    WHERE is_current_job_version = TRUE;
+
+-- (e) Recursive CTE traversal join — two separate indexes replace the OR condition
+--     (io.input_version_uuid = l.output_version_uuid): already exists as idx_run_lineage_denorm_input_version
+--     (io.output_version_uuid = l.input_version_uuid): already exists as idx_run_lineage_denorm_output_version
+--     Add covering composite for the most selective recursive join pattern:
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_run_lineage_denorm_out_to_in
+    ON run_lineage_denormalized (output_version_uuid, input_version_uuid, run_uuid)
+    WHERE output_version_uuid IS NOT NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_run_lineage_denorm_in_to_out
+    ON run_lineage_denormalized (input_version_uuid, output_version_uuid, run_uuid)
+    WHERE input_version_uuid IS NOT NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_run_parent_lineage_denorm_out_to_in
+    ON run_parent_lineage_denormalized (output_version_uuid, input_version_uuid, run_uuid)
+    WHERE output_version_uuid IS NOT NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_run_parent_lineage_denorm_in_to_out
+    ON run_parent_lineage_denormalized (input_version_uuid, output_version_uuid, run_uuid)
+    WHERE input_version_uuid IS NOT NULL;

--- a/api/src/main/resources/marquez/db/migration/V107__create_lineage_edges_and_partition_run_facets.sql
+++ b/api/src/main/resources/marquez/db/migration/V107__create_lineage_edges_and_partition_run_facets.sql
@@ -82,7 +82,7 @@ SELECT
     r.created_at              AS created_at
 FROM runs_input_mapping rim
 INNER JOIN runs r ON r.uuid = rim.run_uuid
-WHERE r.current_run_state IN ('COMPLETE', 'FAILED', 'ABORTED')
+WHERE r.current_run_state IN ('COMPLETED', 'FAILED', 'ABORTED')
 ON CONFLICT (from_node_id, to_node_id, edge_type) DO NOTHING;
 
 -- Output (run) → dataset_version edges
@@ -108,7 +108,7 @@ SELECT
 FROM dataset_versions dv
 INNER JOIN runs r ON r.uuid = dv.run_uuid
 WHERE dv.run_uuid IS NOT NULL
-  AND r.current_run_state IN ('COMPLETE', 'FAILED', 'ABORTED')
+  AND r.current_run_state IN ('COMPLETED', 'FAILED', 'ABORTED')
 ON CONFLICT (from_node_id, to_node_id, edge_type) DO NOTHING;
 
 -- ============================================================

--- a/api/src/main/resources/marquez/db/migration/V107__create_lineage_edges_and_partition_run_facets.sql
+++ b/api/src/main/resources/marquez/db/migration/V107__create_lineage_edges_and_partition_run_facets.sql
@@ -6,6 +6,13 @@
 --   (one per depth level) instead of a single recursive CTE that grows exponentially.
 --   This matches the OpenMetadata pattern but stays inside PostgreSQL.
 --
+--   Design note: lineage_edges is intentionally NOT partitioned.
+--   It stores unique logical edges (one row per physical dataset→dataset connection,
+--   regardless of how many runs traverse that edge). At ~30K new edges/day the table
+--   reaches ~2 GB over 2 years — no partitioning needed. Partitioning on run_date
+--   would also require including run_date in the PRIMARY KEY, which breaks the
+--   global uniqueness constraint on (from_node_id, to_node_id, edge_type).
+--
 -- PART 2: run_facets — advisory comment only
 --   run_facets reaches 10M rows/day at 10 facets × 1M events/day.
 --   At 2 years that is 7.3 billion rows. It must be range-partitioned.
@@ -22,66 +29,29 @@ CREATE TABLE IF NOT EXISTS lineage_edges (
     to_node_id     UUID        NOT NULL,
     to_type        TEXT        NOT NULL,
     edge_type      TEXT        NOT NULL,  -- 'PRODUCES' | 'CONSUMES'
-    run_uuid       UUID        NOT NULL,
-    run_date       DATE        NOT NULL,
+    run_uuid       UUID        NOT NULL,  -- run that first established this edge
+    run_date       DATE        NOT NULL,  -- informational: date edge was first written
     created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    -- Unique per physical edge regardless of which run produced it
+    -- Global uniqueness: one row per physical edge regardless of which run produced it
     CONSTRAINT lineage_edges_pk PRIMARY KEY (from_node_id, to_node_id, edge_type)
-) PARTITION BY RANGE (run_date);
-
--- Monthly partitions for 2024–2026 (extend via PartitionManagementService)
-SELECT create_monthly_partition('lineage_edges', '2024-01-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2024-02-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2024-03-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2024-04-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2024-05-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2024-06-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2024-07-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2024-08-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2024-09-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2024-10-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2024-11-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2024-12-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2025-01-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2025-02-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2025-03-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2025-04-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2025-05-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2025-06-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2025-07-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2025-08-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2025-09-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2025-10-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2025-11-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2025-12-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2026-01-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2026-02-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2026-03-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2026-04-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2026-05-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2026-06-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2026-07-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2026-08-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2026-09-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2026-10-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2026-11-01'::date);
-SELECT create_monthly_partition('lineage_edges', '2026-12-01'::date);
-
--- Catch-all default partition
-CREATE TABLE IF NOT EXISTS lineage_edges_default
-    PARTITION OF lineage_edges DEFAULT;
+);
 
 -- Indexes for bidirectional BFS from application code:
--- upstream traversal:  SELECT from_node_id WHERE to_node_id IN (...)
 -- downstream traversal: SELECT to_node_id WHERE from_node_id IN (...)
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_lineage_edges_downstream
+-- upstream traversal:   SELECT from_node_id WHERE to_node_id IN (...)
+-- Note: CREATE INDEX without CONCURRENTLY is required inside Flyway migrations.
+-- For production systems with millions of existing rows, these can be recreated
+-- with CONCURRENTLY after deployment:
+--   DROP INDEX idx_lineage_edges_downstream;
+--   CREATE INDEX CONCURRENTLY idx_lineage_edges_downstream ON lineage_edges (from_node_id, to_type, run_date DESC);
+CREATE INDEX IF NOT EXISTS idx_lineage_edges_downstream
     ON lineage_edges (from_node_id, to_type, run_date DESC);
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_lineage_edges_upstream
+CREATE INDEX IF NOT EXISTS idx_lineage_edges_upstream
     ON lineage_edges (to_node_id, from_type, run_date DESC);
 
 -- Covering index for run-scoped lookups (find all edges for a run)
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_lineage_edges_run
+CREATE INDEX IF NOT EXISTS idx_lineage_edges_run
     ON lineage_edges (run_uuid, run_date DESC);
 
 -- ============================================================

--- a/api/src/main/resources/marquez/db/migration/V107__create_lineage_edges_and_partition_run_facets.sql
+++ b/api/src/main/resources/marquez/db/migration/V107__create_lineage_edges_and_partition_run_facets.sql
@@ -7,11 +7,11 @@
 --   This matches the OpenMetadata pattern but stays inside PostgreSQL.
 --
 --   Design note: lineage_edges is intentionally NOT partitioned.
---   It stores unique logical edges (one row per physical dataset→dataset connection,
---   regardless of how many runs traverse that edge). At ~30K new edges/day the table
---   reaches ~2 GB over 2 years — no partitioning needed. Partitioning on run_date
---   would also require including run_date in the PRIMARY KEY, which breaks the
---   global uniqueness constraint on (from_node_id, to_node_id, edge_type).
+--   Each row is one hop between a run and a dataset_version (CONSUMES or PRODUCES).
+--   PK (from_node_id, to_node_id, edge_type) deduplicates within a single run.
+--   At ~100K new edges/day (50K CONSUMES + 50K PRODUCES at 5K runs × 10 datasets avg)
+--   the table reaches ~5 GB over 2 years — no partitioning needed. Partitioning on
+--   run_date would require including run_date in the PRIMARY KEY, which is undesirable.
 --
 -- PART 2: run_facets — advisory comment only
 --   run_facets reaches 10M rows/day at 10 facets × 1M events/day.

--- a/api/src/main/resources/marquez/db/migration/V107__create_lineage_edges_and_partition_run_facets.sql
+++ b/api/src/main/resources/marquez/db/migration/V107__create_lineage_edges_and_partition_run_facets.sql
@@ -1,23 +1,24 @@
 -- SPDX-License-Identifier: Apache-2.0
--- V107: Pre-materialized lineage edge table + run_facets partitioning advisory
+-- V107: Pre-materialized lineage edge table (multi-tenant partitioned)
 --
 -- PART 1: lineage_edges — replaces recursive CTE BFS with pre-computed adjacency
 --   Written once per run at COMPLETE/FAIL time. Read as N simple indexed lookups
 --   (one per depth level) instead of a single recursive CTE that grows exponentially.
 --   This matches the OpenMetadata pattern but stays inside PostgreSQL.
 --
---   Design note: lineage_edges is intentionally NOT partitioned.
---   Each row is one hop between a run and a dataset_version (CONSUMES or PRODUCES).
---   PK (from_node_id, to_node_id, edge_type) deduplicates within a single run.
---   At ~100K new edges/day (50K CONSUMES + 50K PRODUCES at 5K runs × 10 datasets avg)
---   the table reaches ~5 GB over 2 years — no partitioning needed. Partitioning on
---   run_date would require including run_date in the PRIMARY KEY, which is undesirable.
+--   Partitioning: composite RANGE (run_date, monthly) -> HASH (namespace, 8),
+--   consistent with the denormalized tables (run_lineage_denormalized is
+--   RANGE-by-run_date; dataset_denormalized is HASH-by-namespace). This gives:
+--     - O(1) retention: DROP an old monthly partition instead of mass DELETE.
+--     - Tenant isolation: each namespace hashes into its own physical sub-partition
+--       so one high-volume tenant's writes/bloat/vacuum do not impact others.
+--   At ~100K new edges/day this reaches ~73M rows over 2 years.
 --
--- PART 2: run_facets — advisory comment only
---   run_facets reaches 10M rows/day at 10 facets × 1M events/day.
---   At 2 years that is 7.3 billion rows. It must be range-partitioned.
---   The actual migration requires a maintenance window and is tracked separately
---   to allow scheduling — see the TODO below.
+--   run_date and namespace are part of the PK. This is safe: every edge has a run
+--   endpoint (run_uuid) whose date and namespace are fixed, so both are
+--   functionally determined by the edge — adding them to the key never admits a
+--   duplicate physical edge. The write path and backfill therefore use
+--   ON CONFLICT (from_node_id, to_node_id, edge_type, run_date, namespace).
 
 -- ============================================================
 -- PART 1: lineage_edges pre-materialized adjacency table
@@ -29,21 +30,59 @@ CREATE TABLE IF NOT EXISTS lineage_edges (
     to_node_id     UUID        NOT NULL,
     to_type        TEXT        NOT NULL,
     edge_type      TEXT        NOT NULL,  -- 'PRODUCES' | 'CONSUMES'
-    run_uuid       UUID        NOT NULL,  -- run that first established this edge
-    run_date       DATE        NOT NULL,  -- informational: date edge was first written
+    namespace      TEXT        NOT NULL,  -- namespace of the run endpoint (tenant)
+    run_uuid       UUID        NOT NULL,  -- run endpoint of this edge
+    run_date       DATE        NOT NULL,  -- range partition key; date of the run
     created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    -- Global uniqueness: one row per physical edge regardless of which run produced it
-    CONSTRAINT lineage_edges_pk PRIMARY KEY (from_node_id, to_node_id, edge_type)
-);
+    CONSTRAINT lineage_edges_pk
+        PRIMARY KEY (from_node_id, to_node_id, edge_type, run_date, namespace)
+) PARTITION BY RANGE (run_date);
 
--- Indexes for bidirectional BFS from application code:
+-- Monthly partitions, each sub-partitioned by HASH(namespace) into 8 buckets.
+-- 2026 is pre-created here (consistent with V101 for the denormalized tables);
+-- PartitionManagementService creates future months on the 1st. Any run_date
+-- outside the created range lands in the DEFAULT partition below.
+DO $$
+DECLARE
+    d     date := '2026-01-01';
+    mname text;
+    h     int;
+BEGIN
+    WHILE d < '2027-01-01' LOOP
+        mname := 'lineage_edges_y' || to_char(d, 'YYYY') || 'm' || to_char(d, 'MM');
+        EXECUTE format(
+            'CREATE TABLE IF NOT EXISTS %I PARTITION OF lineage_edges '
+            || 'FOR VALUES FROM (%L) TO (%L) PARTITION BY HASH (namespace)',
+            mname, d, (d + INTERVAL '1 month')::date);
+        FOR h IN 0..7 LOOP
+            EXECUTE format(
+                'CREATE TABLE IF NOT EXISTS %I PARTITION OF %I '
+                || 'FOR VALUES WITH (MODULUS 8, REMAINDER %s)',
+                mname || '_h' || h, mname, h);
+        END LOOP;
+        d := (d + INTERVAL '1 month')::date;
+    END LOOP;
+END $$;
+
+-- DEFAULT safety-net month, also HASH(namespace)-subpartitioned. Catches any
+-- run_date outside the created range (alert when rows land here — it means a
+-- monthly partition is missing).
+CREATE TABLE IF NOT EXISTS lineage_edges_default
+    PARTITION OF lineage_edges DEFAULT PARTITION BY HASH (namespace);
+DO $$
+DECLARE h int;
+BEGIN
+    FOR h IN 0..7 LOOP
+        EXECUTE format(
+            'CREATE TABLE IF NOT EXISTS lineage_edges_default_h%s '
+            || 'PARTITION OF lineage_edges_default FOR VALUES WITH (MODULUS 8, REMAINDER %s)',
+            h, h);
+    END LOOP;
+END $$;
+
+-- Indexes on the parent propagate to every partition (existing + future):
 -- downstream traversal: SELECT to_node_id WHERE from_node_id IN (...)
 -- upstream traversal:   SELECT from_node_id WHERE to_node_id IN (...)
--- Note: CREATE INDEX without CONCURRENTLY is required inside Flyway migrations.
--- For production systems with millions of existing rows, these can be recreated
--- with CONCURRENTLY after deployment:
---   DROP INDEX idx_lineage_edges_downstream;
---   CREATE INDEX CONCURRENTLY idx_lineage_edges_downstream ON lineage_edges (from_node_id, to_type, run_date DESC);
 CREATE INDEX IF NOT EXISTS idx_lineage_edges_downstream
     ON lineage_edges (from_node_id, to_type, run_date DESC);
 
@@ -57,19 +96,13 @@ CREATE INDEX IF NOT EXISTS idx_lineage_edges_run
 -- ============================================================
 -- PART 2: Backfill lineage_edges from existing normalized data
 -- ============================================================
--- Populate historical dataset_version → run edges from runs_input_mapping.
--- This is a one-time backfill; new edges are written by DenormalizedLineageService
--- at COMPLETE/FAIL event time.
+-- One-time backfill of historical edges; new edges are written by
+-- DenormalizedLineageService at COMPLETE/FAIL/ABORT event time.
 
+-- Input dataset_version -> run edges (CONSUMES)
 INSERT INTO lineage_edges (
-    from_node_id,
-    from_type,
-    to_node_id,
-    to_type,
-    edge_type,
-    run_uuid,
-    run_date,
-    created_at
+    from_node_id, from_type, to_node_id, to_type, edge_type,
+    namespace, run_uuid, run_date, created_at
 )
 SELECT
     rim.dataset_version_uuid  AS from_node_id,
@@ -77,24 +110,19 @@ SELECT
     r.uuid                    AS to_node_id,
     'run'                     AS to_type,
     'CONSUMES'                AS edge_type,
+    r.namespace_name          AS namespace,
     r.uuid                    AS run_uuid,
     r.created_at::date        AS run_date,
     r.created_at              AS created_at
 FROM runs_input_mapping rim
 INNER JOIN runs r ON r.uuid = rim.run_uuid
 WHERE r.current_run_state IN ('COMPLETED', 'FAILED', 'ABORTED')
-ON CONFLICT (from_node_id, to_node_id, edge_type) DO NOTHING;
+ON CONFLICT (from_node_id, to_node_id, edge_type, run_date, namespace) DO NOTHING;
 
--- Output (run) → dataset_version edges
+-- Output run -> dataset_version edges (PRODUCES)
 INSERT INTO lineage_edges (
-    from_node_id,
-    from_type,
-    to_node_id,
-    to_type,
-    edge_type,
-    run_uuid,
-    run_date,
-    created_at
+    from_node_id, from_type, to_node_id, to_type, edge_type,
+    namespace, run_uuid, run_date, created_at
 )
 SELECT
     dv.run_uuid               AS from_node_id,
@@ -102,6 +130,7 @@ SELECT
     dv.uuid                   AS to_node_id,
     'dataset_version'         AS to_type,
     'PRODUCES'                AS edge_type,
+    r.namespace_name          AS namespace,
     dv.run_uuid               AS run_uuid,
     dv.created_at::date       AS run_date,
     dv.created_at             AS created_at
@@ -109,19 +138,15 @@ FROM dataset_versions dv
 INNER JOIN runs r ON r.uuid = dv.run_uuid
 WHERE dv.run_uuid IS NOT NULL
   AND r.current_run_state IN ('COMPLETED', 'FAILED', 'ABORTED')
-ON CONFLICT (from_node_id, to_node_id, edge_type) DO NOTHING;
+ON CONFLICT (from_node_id, to_node_id, edge_type, run_date, namespace) DO NOTHING;
 
 -- ============================================================
--- TODO: run_facets partitioning
+-- TODO: large raw-table partitioning (V108)
 -- ============================================================
--- run_facets grows at 10M rows/day (10 facets × 1M events/day).
--- At this rate it reaches 7.3 billion rows in 2 years (~1.1 TB).
--- Partitioning requires:
---   1. CREATE TABLE run_facets_new (...) PARTITION BY RANGE (lineage_event_time)
---   2. Create monthly partitions 2024-01 through 2026-12
---   3. COPY data from run_facets to run_facets_new in batches
---   4. Rename tables atomically
--- This migration is tracked separately as V108 and requires a maintenance window.
--- Run the following to estimate current table size before scheduling:
+-- run_facets (~7.3B rows/2yr), dataset_facets, and lineage_events use the same
+-- composite RANGE(event_date) -> HASH(namespace) scheme. They are populated, so
+-- V108 partitions them via shadow-table + batched copy + atomic rename swap in a
+-- maintenance window, and adds a namespace column to run_facets/dataset_facets
+-- (lineage_events already has job_namespace). Estimate before scheduling:
 --   SELECT pg_size_pretty(pg_total_relation_size('run_facets'));
 --   SELECT count(*) FROM run_facets;

--- a/api/src/main/resources/marquez/db/migration/V107__create_lineage_edges_and_partition_run_facets.sql
+++ b/api/src/main/resources/marquez/db/migration/V107__create_lineage_edges_and_partition_run_facets.sql
@@ -1,0 +1,157 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- V107: Pre-materialized lineage edge table + run_facets partitioning advisory
+--
+-- PART 1: lineage_edges — replaces recursive CTE BFS with pre-computed adjacency
+--   Written once per run at COMPLETE/FAIL time. Read as N simple indexed lookups
+--   (one per depth level) instead of a single recursive CTE that grows exponentially.
+--   This matches the OpenMetadata pattern but stays inside PostgreSQL.
+--
+-- PART 2: run_facets — advisory comment only
+--   run_facets reaches 10M rows/day at 10 facets × 1M events/day.
+--   At 2 years that is 7.3 billion rows. It must be range-partitioned.
+--   The actual migration requires a maintenance window and is tracked separately
+--   to allow scheduling — see the TODO below.
+
+-- ============================================================
+-- PART 1: lineage_edges pre-materialized adjacency table
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS lineage_edges (
+    from_node_id   UUID        NOT NULL,
+    from_type      TEXT        NOT NULL,  -- 'dataset_version' | 'run' | 'job'
+    to_node_id     UUID        NOT NULL,
+    to_type        TEXT        NOT NULL,
+    edge_type      TEXT        NOT NULL,  -- 'PRODUCES' | 'CONSUMES'
+    run_uuid       UUID        NOT NULL,
+    run_date       DATE        NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- Unique per physical edge regardless of which run produced it
+    CONSTRAINT lineage_edges_pk PRIMARY KEY (from_node_id, to_node_id, edge_type)
+) PARTITION BY RANGE (run_date);
+
+-- Monthly partitions for 2024–2026 (extend via PartitionManagementService)
+SELECT create_monthly_partition('lineage_edges', '2024-01-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2024-02-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2024-03-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2024-04-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2024-05-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2024-06-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2024-07-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2024-08-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2024-09-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2024-10-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2024-11-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2024-12-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2025-01-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2025-02-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2025-03-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2025-04-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2025-05-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2025-06-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2025-07-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2025-08-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2025-09-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2025-10-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2025-11-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2025-12-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2026-01-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2026-02-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2026-03-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2026-04-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2026-05-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2026-06-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2026-07-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2026-08-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2026-09-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2026-10-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2026-11-01'::date);
+SELECT create_monthly_partition('lineage_edges', '2026-12-01'::date);
+
+-- Catch-all default partition
+CREATE TABLE IF NOT EXISTS lineage_edges_default
+    PARTITION OF lineage_edges DEFAULT;
+
+-- Indexes for bidirectional BFS from application code:
+-- upstream traversal:  SELECT from_node_id WHERE to_node_id IN (...)
+-- downstream traversal: SELECT to_node_id WHERE from_node_id IN (...)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_lineage_edges_downstream
+    ON lineage_edges (from_node_id, to_type, run_date DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_lineage_edges_upstream
+    ON lineage_edges (to_node_id, from_type, run_date DESC);
+
+-- Covering index for run-scoped lookups (find all edges for a run)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_lineage_edges_run
+    ON lineage_edges (run_uuid, run_date DESC);
+
+-- ============================================================
+-- PART 2: Backfill lineage_edges from existing normalized data
+-- ============================================================
+-- Populate historical dataset_version → run edges from runs_input_mapping.
+-- This is a one-time backfill; new edges are written by DenormalizedLineageService
+-- at COMPLETE/FAIL event time.
+
+INSERT INTO lineage_edges (
+    from_node_id,
+    from_type,
+    to_node_id,
+    to_type,
+    edge_type,
+    run_uuid,
+    run_date,
+    created_at
+)
+SELECT
+    rim.dataset_version_uuid  AS from_node_id,
+    'dataset_version'         AS from_type,
+    r.uuid                    AS to_node_id,
+    'run'                     AS to_type,
+    'CONSUMES'                AS edge_type,
+    r.uuid                    AS run_uuid,
+    r.created_at::date        AS run_date,
+    r.created_at              AS created_at
+FROM runs_input_mapping rim
+INNER JOIN runs r ON r.uuid = rim.run_uuid
+WHERE r.current_run_state IN ('COMPLETE', 'FAILED', 'ABORTED')
+ON CONFLICT (from_node_id, to_node_id, edge_type) DO NOTHING;
+
+-- Output (run) → dataset_version edges
+INSERT INTO lineage_edges (
+    from_node_id,
+    from_type,
+    to_node_id,
+    to_type,
+    edge_type,
+    run_uuid,
+    run_date,
+    created_at
+)
+SELECT
+    dv.run_uuid               AS from_node_id,
+    'run'                     AS from_type,
+    dv.uuid                   AS to_node_id,
+    'dataset_version'         AS to_type,
+    'PRODUCES'                AS edge_type,
+    dv.run_uuid               AS run_uuid,
+    dv.created_at::date       AS run_date,
+    dv.created_at             AS created_at
+FROM dataset_versions dv
+INNER JOIN runs r ON r.uuid = dv.run_uuid
+WHERE dv.run_uuid IS NOT NULL
+  AND r.current_run_state IN ('COMPLETE', 'FAILED', 'ABORTED')
+ON CONFLICT (from_node_id, to_node_id, edge_type) DO NOTHING;
+
+-- ============================================================
+-- TODO: run_facets partitioning
+-- ============================================================
+-- run_facets grows at 10M rows/day (10 facets × 1M events/day).
+-- At this rate it reaches 7.3 billion rows in 2 years (~1.1 TB).
+-- Partitioning requires:
+--   1. CREATE TABLE run_facets_new (...) PARTITION BY RANGE (lineage_event_time)
+--   2. Create monthly partitions 2024-01 through 2026-12
+--   3. COPY data from run_facets to run_facets_new in batches
+--   4. Rename tables atomically
+-- This migration is tracked separately as V108 and requires a maintenance window.
+-- Run the following to estimate current table size before scheduling:
+--   SELECT pg_size_pretty(pg_total_relation_size('run_facets'));
+--   SELECT count(*) FROM run_facets;

--- a/api/src/main/resources/marquez/db/migration/V108__partition_run_facets.sql
+++ b/api/src/main/resources/marquez/db/migration/V108__partition_run_facets.sql
@@ -1,40 +1,66 @@
 -- SPDX-License-Identifier: Apache-2.0
 -- V108: Partition run_facets by event time + namespace (multi-tenant, 2-year scale)
 --
--- run_facets is the largest table at 1M events/day: ~10 facets/event → ~10M rows/day
--- → ~7.3B rows (~1.1 TB) over 2 years. Plain and unbounded today. Partition it with
--- the same composite scheme as lineage_edges and the denormalized tables:
+-- run_facets is the largest table at 1M events/day: ~10 facets/event -> ~10M rows/day
+-- -> ~7.3B rows (~1.1 TB) over 2 years. Partition it with the same composite scheme as
+-- lineage_edges and the denormalized tables:
 --   RANGE (lineage_event_time, monthly) -> HASH (namespace, 8) + hash-subpartitioned DEFAULT
--- giving O(1) retention (DROP an old month) and tenant isolation (a high-volume
--- namespace hashes into its own physical sub-partition).
+-- giving O(1) retention (DROP an old month) and tenant isolation.
 --
--- run_facets has no PRIMARY KEY and is INSERT-only (no ON CONFLICT), so there is no
--- unique constraint to fold the partition keys into. namespace is denormalized from
--- the run's namespace; it is nullable (run_uuid is nullable) — HASH routes NULL to a
--- fixed bucket.
+-- ONLINE, SIZE-BRANCHED CUTOVER
+-- ----------------------------
+-- Converting a plain table to partitioned requires a shadow table + copy + swap. On a
+-- large populated table that copy must NOT run inline at startup (it would block boot for
+-- hours). So this migration branches on the CURRENT size of run_facets:
 --
--- Tables are populated, so partition via shadow table + copy + atomic rename swap.
--- On a fresh/empty database (CI, new installs) the copy is a no-op. Validated end to
--- end on PostgreSQL (rolled-back transaction against the real schema).
+--   * Small / empty (<= 1 GiB — fresh installs, CI, dev): copy + swap INLINE now. Instant
+--     on an empty table; keeps run_facets partitioned the moment migrations finish, so the
+--     rest of the system (V110 lifecycle, tests) sees the final shape immediately.
 --
--- Dependent objects: run_facets_view (trivial SELECT * — recreated below). The
--- matviews run_lineage_view and run_parent_lineage_view depend on run_facets but are
--- DEAD — their refresher (RunLineageMaterializeViewRefresherJob) is disabled and the
--- active MaterializeViewRefresherJob only refreshes lineage_events_by_type_hourly_view,
--- so they are dropped here rather than recreated.
+--   * Large (> 1 GiB — real production): set up an ONLINE cutover instead. Create the empty
+--     partitioned shadow and an AFTER INSERT trigger that mirrors every new row into it, and
+--     record a cutover timestamp. The heavy historical copy + final swap are deferred to the
+--     RUN_FACETS_PARTITION_V1 background backfill job (BackfillOrchestrator), which runs off
+--     the startup path. run_facets stays the live table (source of truth) until the job does a
+--     count-verified atomic swap — so nothing is lost even if the copy is interrupted.
+--
+-- Boundary (exactly-once, no primary key needed): the trigger mirrors only rows with
+-- created_at >= cutover; the backfill copies only rows with created_at < cutover. Disjoint by
+-- value, so no row is copied twice and none is missed, independent of commit ordering. The
+-- backfill additionally count-verifies (old vs shadow) under a brief lock before swapping, and
+-- the shadow is disposable until then, so a mismatch just rebuilds rather than losing data.
+--
+-- created_at is the app's write-time Instant (RunFacetsDao), i.e. when the row was written —
+-- the correct quantity for this boundary (distinct from lineage_event_time, the event clock).
 
--- 1. Denormalize namespace onto run_facets, then build the partitioned shadow.
+-- 1. Denormalize namespace onto run_facets (nullable, instant — no table rewrite).
 ALTER TABLE run_facets ADD COLUMN IF NOT EXISTS namespace TEXT;
-UPDATE run_facets rf
-   SET namespace = r.namespace_name
-  FROM runs r
- WHERE r.uuid = rf.run_uuid
-   AND rf.namespace IS NULL;
 
-CREATE TABLE run_facets_p (LIKE run_facets INCLUDING DEFAULTS INCLUDING INDEXES)
+-- 2. Drop the DEAD matviews that pin run_facets by OID (their refresher
+--    RunLineageMaterializeViewRefresherJob is disabled; the active MaterializeViewRefresherJob
+--    only refreshes lineage_events_by_type_hourly_view). Not recreated. Removing them now keeps
+--    the later rename swap (inline or deferred) unobstructed.
+DROP MATERIALIZED VIEW IF EXISTS run_lineage_view;
+DROP MATERIALIZED VIEW IF EXISTS run_parent_lineage_view;
+
+-- 3. Mirror trigger function: copy one row into the partitioned shadow, resolving namespace
+--    (already set by the app; subselect is a fallback for any other writer).
+CREATE OR REPLACE FUNCTION run_facets_mirror_to_partition() RETURNS trigger AS $$
+BEGIN
+    INSERT INTO run_facets_p (
+        created_at, run_uuid, lineage_event_time, lineage_event_type, name, facet, namespace)
+    VALUES (
+        NEW.created_at, NEW.run_uuid, NEW.lineage_event_time, NEW.lineage_event_type,
+        NEW.name, NEW.facet,
+        COALESCE(NEW.namespace, (SELECT namespace_name FROM runs WHERE uuid = NEW.run_uuid)));
+    RETURN NULL; -- AFTER trigger
+END;
+$$ LANGUAGE plpgsql;
+
+-- 4. The empty partitioned shadow (always built; identical shape to run_facets).
+CREATE TABLE IF NOT EXISTS run_facets_p (LIKE run_facets INCLUDING DEFAULTS INCLUDING INDEXES)
     PARTITION BY RANGE (lineage_event_time);
 
--- Monthly partitions for 2026 (consistent with V101/V107), each HASH(namespace) x8.
 DO $$
 DECLARE
     d     date := '2026-01-01';
@@ -57,8 +83,7 @@ BEGIN
     END LOOP;
 END $$;
 
--- DEFAULT safety-net month, also HASH(namespace)-subpartitioned.
-CREATE TABLE run_facets_p_default
+CREATE TABLE IF NOT EXISTS run_facets_p_default
     PARTITION OF run_facets_p DEFAULT PARTITION BY HASH (namespace);
 DO $$
 DECLARE h int;
@@ -71,25 +96,62 @@ BEGIN
     END LOOP;
 END $$;
 
--- 2. Copy existing rows into the partitioned table (no-op on a fresh DB).
-INSERT INTO run_facets_p SELECT * FROM run_facets;
+-- 5. Cutover state marker (single row). state = 'SWAPPED' (done, inline) | 'DUAL_WRITE'
+--    (online cutover in progress — the backfill job will copy + swap).
+CREATE TABLE IF NOT EXISTS run_facets_partition_state (
+    singleton  boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+    state      text        NOT NULL,
+    cutover_at timestamptz NOT NULL DEFAULT now()
+);
 
--- 3. Drop dependents that pin the old table by OID: the trivial view (recreated
---    below) and the two dead matviews (not recreated — see header).
-DROP VIEW IF EXISTS run_facets_view;
-DROP MATERIALIZED VIEW IF EXISTS run_lineage_view;
-DROP MATERIALIZED VIEW IF EXISTS run_parent_lineage_view;
+-- 6. Size branch: small/empty -> inline swap now; large -> online (trigger + defer).
+DO $$
+DECLARE
+    v_bytes   bigint;
+    v_cutover timestamptz := clock_timestamp();
+BEGIN
+    v_bytes := pg_total_relation_size('run_facets');
 
--- 4. Atomic swap, then restore the FK (LIKE does not copy FKs) and the view.
-ALTER TABLE run_facets RENAME TO run_facets_old;
-ALTER TABLE run_facets_p RENAME TO run_facets;
+    IF v_bytes <= 1073741824 THEN
+        -- SMALL / EMPTY: copy + swap synchronously (instant on an empty table).
+        UPDATE run_facets rf
+           SET namespace = r.namespace_name
+          FROM runs r
+         WHERE r.uuid = rf.run_uuid AND rf.namespace IS NULL;
 
-ALTER TABLE run_facets
-    ADD CONSTRAINT run_facets_run_uuid_fkey
-    FOREIGN KEY (run_uuid) REFERENCES runs (uuid) ON DELETE CASCADE;
+        INSERT INTO run_facets_p (
+            created_at, run_uuid, lineage_event_time, lineage_event_type, name, facet, namespace)
+        SELECT created_at, run_uuid, lineage_event_time, lineage_event_type, name, facet, namespace
+          FROM run_facets;
 
-CREATE VIEW run_facets_view AS
-    SELECT created_at, run_uuid, lineage_event_time, lineage_event_type, name, facet
-    FROM run_facets;
+        DROP VIEW IF EXISTS run_facets_view;
+        ALTER TABLE run_facets   RENAME TO run_facets_old;
+        ALTER TABLE run_facets_p RENAME TO run_facets;
+        ALTER TABLE run_facets
+            ADD CONSTRAINT run_facets_run_uuid_fkey
+            FOREIGN KEY (run_uuid) REFERENCES runs (uuid) ON DELETE CASCADE;
+        EXECUTE 'CREATE VIEW run_facets_view AS '
+             || 'SELECT created_at, run_uuid, lineage_event_time, lineage_event_type, name, facet '
+             || 'FROM run_facets';
+        DROP TABLE run_facets_old;
 
-DROP TABLE run_facets_old;
+        INSERT INTO run_facets_partition_state (singleton, state, cutover_at)
+             VALUES (true, 'SWAPPED', v_cutover)
+        ON CONFLICT (singleton) DO UPDATE SET state = 'SWAPPED', cutover_at = EXCLUDED.cutover_at;
+
+        RAISE NOTICE 'run_facets partitioned inline (% bytes <= 1 GiB).', v_bytes;
+    ELSE
+        -- LARGE: online cutover. Mirror new rows (created_at >= cutover) into the shadow; the
+        -- backfill job copies history (created_at < cutover) and performs the verified swap.
+        EXECUTE format(
+            'CREATE TRIGGER run_facets_mirror_trg AFTER INSERT ON run_facets '
+            || 'FOR EACH ROW WHEN (NEW.created_at >= %L::timestamptz) '
+            || 'EXECUTE FUNCTION run_facets_mirror_to_partition()', v_cutover);
+
+        INSERT INTO run_facets_partition_state (singleton, state, cutover_at)
+             VALUES (true, 'DUAL_WRITE', v_cutover)
+        ON CONFLICT (singleton) DO UPDATE SET state = 'DUAL_WRITE', cutover_at = EXCLUDED.cutover_at;
+
+        RAISE NOTICE 'run_facets online cutover armed (% bytes > 1 GiB); RUN_FACETS_PARTITION_V1 will copy + swap.', v_bytes;
+    END IF;
+END $$;

--- a/api/src/main/resources/marquez/db/migration/V108__partition_run_facets.sql
+++ b/api/src/main/resources/marquez/db/migration/V108__partition_run_facets.sql
@@ -1,0 +1,95 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- V108: Partition run_facets by event time + namespace (multi-tenant, 2-year scale)
+--
+-- run_facets is the largest table at 1M events/day: ~10 facets/event → ~10M rows/day
+-- → ~7.3B rows (~1.1 TB) over 2 years. Plain and unbounded today. Partition it with
+-- the same composite scheme as lineage_edges and the denormalized tables:
+--   RANGE (lineage_event_time, monthly) -> HASH (namespace, 8) + hash-subpartitioned DEFAULT
+-- giving O(1) retention (DROP an old month) and tenant isolation (a high-volume
+-- namespace hashes into its own physical sub-partition).
+--
+-- run_facets has no PRIMARY KEY and is INSERT-only (no ON CONFLICT), so there is no
+-- unique constraint to fold the partition keys into. namespace is denormalized from
+-- the run's namespace; it is nullable (run_uuid is nullable) — HASH routes NULL to a
+-- fixed bucket.
+--
+-- Tables are populated, so partition via shadow table + copy + atomic rename swap.
+-- On a fresh/empty database (CI, new installs) the copy is a no-op. Validated end to
+-- end on PostgreSQL (rolled-back transaction against the real schema).
+--
+-- Dependent objects: run_facets_view (trivial SELECT * — recreated below). The
+-- matviews run_lineage_view and run_parent_lineage_view depend on run_facets but are
+-- DEAD — their refresher (RunLineageMaterializeViewRefresherJob) is disabled and the
+-- active MaterializeViewRefresherJob only refreshes lineage_events_by_type_hourly_view,
+-- so they are dropped here rather than recreated.
+
+-- 1. Denormalize namespace onto run_facets, then build the partitioned shadow.
+ALTER TABLE run_facets ADD COLUMN IF NOT EXISTS namespace TEXT;
+UPDATE run_facets rf
+   SET namespace = r.namespace_name
+  FROM runs r
+ WHERE r.uuid = rf.run_uuid
+   AND rf.namespace IS NULL;
+
+CREATE TABLE run_facets_p (LIKE run_facets INCLUDING DEFAULTS INCLUDING INDEXES)
+    PARTITION BY RANGE (lineage_event_time);
+
+-- Monthly partitions for 2026 (consistent with V101/V107), each HASH(namespace) x8.
+DO $$
+DECLARE
+    d     date := '2026-01-01';
+    mname text;
+    h     int;
+BEGIN
+    WHILE d < '2027-01-01' LOOP
+        mname := 'run_facets_p_y' || to_char(d, 'YYYY') || 'm' || to_char(d, 'MM');
+        EXECUTE format(
+            'CREATE TABLE IF NOT EXISTS %I PARTITION OF run_facets_p '
+            || 'FOR VALUES FROM (%L) TO (%L) PARTITION BY HASH (namespace)',
+            mname, d, (d + INTERVAL '1 month')::date);
+        FOR h IN 0..7 LOOP
+            EXECUTE format(
+                'CREATE TABLE IF NOT EXISTS %I PARTITION OF %I '
+                || 'FOR VALUES WITH (MODULUS 8, REMAINDER %s)',
+                mname || '_h' || h, mname, h);
+        END LOOP;
+        d := (d + INTERVAL '1 month')::date;
+    END LOOP;
+END $$;
+
+-- DEFAULT safety-net month, also HASH(namespace)-subpartitioned.
+CREATE TABLE run_facets_p_default
+    PARTITION OF run_facets_p DEFAULT PARTITION BY HASH (namespace);
+DO $$
+DECLARE h int;
+BEGIN
+    FOR h IN 0..7 LOOP
+        EXECUTE format(
+            'CREATE TABLE IF NOT EXISTS run_facets_p_default_h%s '
+            || 'PARTITION OF run_facets_p_default FOR VALUES WITH (MODULUS 8, REMAINDER %s)',
+            h, h);
+    END LOOP;
+END $$;
+
+-- 2. Copy existing rows into the partitioned table (no-op on a fresh DB).
+INSERT INTO run_facets_p SELECT * FROM run_facets;
+
+-- 3. Drop dependents that pin the old table by OID: the trivial view (recreated
+--    below) and the two dead matviews (not recreated — see header).
+DROP VIEW IF EXISTS run_facets_view;
+DROP MATERIALIZED VIEW IF EXISTS run_lineage_view;
+DROP MATERIALIZED VIEW IF EXISTS run_parent_lineage_view;
+
+-- 4. Atomic swap, then restore the FK (LIKE does not copy FKs) and the view.
+ALTER TABLE run_facets RENAME TO run_facets_old;
+ALTER TABLE run_facets_p RENAME TO run_facets;
+
+ALTER TABLE run_facets
+    ADD CONSTRAINT run_facets_run_uuid_fkey
+    FOREIGN KEY (run_uuid) REFERENCES runs (uuid) ON DELETE CASCADE;
+
+CREATE VIEW run_facets_view AS
+    SELECT created_at, run_uuid, lineage_event_time, lineage_event_type, name, facet
+    FROM run_facets;
+
+DROP TABLE run_facets_old;

--- a/api/src/main/resources/marquez/db/migration/V109__add_job_dataset_lineage_edges.sql
+++ b/api/src/main/resources/marquez/db/migration/V109__add_job_dataset_lineage_edges.sql
@@ -1,0 +1,63 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- V109: Generalize lineage_edges to job<->dataset edges (job & dataset lineage)
+--
+-- lineage_edges already stores run<->dataset_version edges (run / dataset-version
+-- lineage). Extend the same adjacency table + BFS pattern to JOB and DATASET
+-- lineage by adding job<->dataset edges:
+--   INPUT  (job reads dataset):  dataset --CONSUMES--> job
+--   OUTPUT (job writes dataset): job    --PRODUCES--> dataset
+-- A BFS over these reproduces the job-lineage adjacency (two jobs are connected
+-- when they share ANY dataset): job -> all its datasets -> all jobs touching them.
+--
+-- Job edges have no run, so run_uuid is relaxed to NULL. The partition key run_date
+-- is the date the job version became current (made_current_at), and namespace is the
+-- job's namespace — so job edges get the same RANGE(run_date)->HASH(namespace)
+-- tenant isolation + retention as run edges. node-id spaces are disjoint (job/dataset
+-- UUIDs never collide with run/dataset_version UUIDs), so the two edge families
+-- coexist without ambiguity.
+
+-- 1. Job edges carry no run.
+ALTER TABLE lineage_edges ALTER COLUMN run_uuid DROP NOT NULL;
+
+-- 2. Backfill current job<->dataset edges from job_versions_io_mapping.
+--    CONSUMES: input dataset -> job
+INSERT INTO lineage_edges (
+    from_node_id, from_type, to_node_id, to_type, edge_type,
+    namespace, run_uuid, run_date, created_at
+)
+SELECT DISTINCT
+    jvio.dataset_uuid AS from_node_id,
+    'dataset'         AS from_type,
+    jvio.job_uuid     AS to_node_id,
+    'job'             AS to_type,
+    'CONSUMES'        AS edge_type,
+    j.namespace_name  AS namespace,
+    NULL::uuid        AS run_uuid,
+    DATE(COALESCE(jvio.made_current_at, j.updated_at, j.created_at)) AS run_date,
+    NOW()             AS created_at
+FROM job_versions_io_mapping jvio
+INNER JOIN jobs j ON j.uuid = jvio.job_uuid
+WHERE jvio.is_current_job_version = TRUE
+  AND jvio.io_type = 'INPUT'
+ON CONFLICT (from_node_id, to_node_id, edge_type, run_date, namespace) DO NOTHING;
+
+--    PRODUCES: job -> output dataset
+INSERT INTO lineage_edges (
+    from_node_id, from_type, to_node_id, to_type, edge_type,
+    namespace, run_uuid, run_date, created_at
+)
+SELECT DISTINCT
+    jvio.job_uuid     AS from_node_id,
+    'job'             AS from_type,
+    jvio.dataset_uuid AS to_node_id,
+    'dataset'         AS to_type,
+    'PRODUCES'        AS edge_type,
+    j.namespace_name  AS namespace,
+    NULL::uuid        AS run_uuid,
+    DATE(COALESCE(jvio.made_current_at, j.updated_at, j.created_at)) AS run_date,
+    NOW()             AS created_at
+FROM job_versions_io_mapping jvio
+INNER JOIN jobs j ON j.uuid = jvio.job_uuid
+WHERE jvio.is_current_job_version = TRUE
+  AND jvio.io_type = 'OUTPUT'
+ON CONFLICT (from_node_id, to_node_id, edge_type, run_date, namespace) DO NOTHING;

--- a/api/src/main/resources/marquez/db/migration/V110__composite_partition_management_functions.sql
+++ b/api/src/main/resources/marquez/db/migration/V110__composite_partition_management_functions.sql
@@ -1,0 +1,97 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- V110: Lifecycle helpers for the composite RANGE(date)->HASH(namespace) tables
+--
+-- V107 (lineage_edges) and V108 (run_facets) introduced two-level partitioning:
+--   PARTITION BY RANGE (date) -> each month PARTITION BY HASH (namespace, 8).
+-- The pre-existing create_monthly_partition()/drop_old_partitions() helpers only
+-- understand the single-level denormalized tables (they create flat RANGE
+-- partitions and denorm-specific indexes), so they cannot manage these tables.
+-- Two new helpers create the monthly RANGE->HASH subtree and retire whole months.
+--
+-- Naming note: run_facets was partitioned via shadow-table swap, so its monthly
+-- partitions keep the shadow prefix (run_facets_p_y2026m01) even though the parent
+-- is now `run_facets`. The create helper therefore takes the partition name prefix
+-- separately from the parent table; the drop helper discovers children via
+-- pg_inherits (prefix-agnostic) so it works regardless of naming.
+
+-- create_monthly_hash_partition: create one monthly RANGE partition that is itself
+-- HASH(namespace)-subpartitioned into `hash_modulus` buckets. Indexes are NOT
+-- created here — Postgres propagates the parent's partitioned indexes to every new
+-- partition automatically. Advisory-locked + exception-guarded so concurrent
+-- schedulers and re-runs are safe.
+CREATE OR REPLACE FUNCTION create_monthly_hash_partition(
+    parent_table text, partition_prefix text, start_date date, hash_modulus integer)
+RETURNS void AS $$
+DECLARE
+    mname    text;
+    end_date date;
+    h        int;
+    lock_key bigint;
+BEGIN
+    start_date := date_trunc('month', start_date)::date;
+    end_date   := (start_date + INTERVAL '1 month')::date;
+    mname      := partition_prefix || '_y' || to_char(start_date, 'YYYY') || 'm' || to_char(start_date, 'MM');
+
+    -- Serialize concurrent creation of the same month.
+    lock_key := ('x' || substr(md5(mname), 1, 15))::bit(60)::bigint;
+    PERFORM pg_advisory_xact_lock(lock_key);
+
+    BEGIN
+        EXECUTE format(
+            'CREATE TABLE IF NOT EXISTS %I PARTITION OF %I '
+            || 'FOR VALUES FROM (%L) TO (%L) PARTITION BY HASH (namespace)',
+            mname, parent_table, start_date, end_date);
+
+        FOR h IN 0..(hash_modulus - 1) LOOP
+            EXECUTE format(
+                'CREATE TABLE IF NOT EXISTS %I PARTITION OF %I '
+                || 'FOR VALUES WITH (MODULUS %s, REMAINDER %s)',
+                mname || '_h' || h, mname, hash_modulus, h);
+        END LOOP;
+    EXCEPTION
+        WHEN OTHERS THEN
+            -- Overlap / already-exists ⇒ the work is already done.
+            RAISE NOTICE 'Skipping partition % (already exists or overlaps): %', mname, SQLERRM;
+    END;
+END;
+$$ LANGUAGE plpgsql;
+
+-- drop_old_hash_partitions: detach+drop whole monthly partitions of `parent_table`
+-- whose month is older than `retention_months`. Children are discovered via
+-- pg_inherits (so the run_facets `_p` prefix and the DEFAULT partition are handled
+-- correctly: DEFAULT has no y####m## suffix and is skipped). DROP ... CASCADE
+-- removes the month's hash sub-partitions with it.
+CREATE OR REPLACE FUNCTION drop_old_hash_partitions(
+    parent_table regclass, retention_months integer)
+RETURNS void AS $$
+DECLARE
+    cutoff_date date;
+    child       record;
+    part_date   date;
+BEGIN
+    -- First day of the oldest month we keep.
+    cutoff_date := (date_trunc('month', CURRENT_DATE) - (retention_months || ' months')::interval)::date;
+
+    FOR child IN
+        SELECT inhrelid::regclass::text AS child_name
+        FROM pg_inherits
+        WHERE inhparent = parent_table
+    LOOP
+        -- Monthly partitions end in y####m##; DEFAULT and anything else is skipped.
+        -- Capture year and month separately (substring(... from pattern) only returns
+        -- the first capture group, so a single y(####)m(##) group would drop the month)
+        -- and concatenate to YYYYMM for an exact, month-precise date.
+        IF child.child_name ~ 'y[0-9]{4}m[0-9]{2}$' THEN
+            part_date := to_date(
+                substring(child.child_name from 'y([0-9]{4})m[0-9]{2}$')
+                || substring(child.child_name from 'y[0-9]{4}m([0-9]{2})$'),
+                'YYYYMM');
+            IF part_date < cutoff_date THEN
+                EXECUTE format('DROP TABLE IF EXISTS %s CASCADE', child.child_name);
+                RAISE NOTICE 'Dropped partition % (month %, cutoff %)',
+                    child.child_name, part_date, cutoff_date;
+            END IF;
+        END IF;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;

--- a/api/src/main/resources/marquez/db/migration/V111__partition_dataset_facets.sql
+++ b/api/src/main/resources/marquez/db/migration/V111__partition_dataset_facets.sql
@@ -1,0 +1,133 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- V111: Partition dataset_facets by event time + namespace (online, startup-safe)
+--
+-- Same composite scheme + online cutover as run_facets (V108):
+--   RANGE (lineage_event_time, monthly) -> HASH (namespace, 8) + hash-subpartitioned DEFAULT
+-- Size-branched so it never blocks startup:
+--   * Small / empty (<= 1 GiB): copy + atomic rename swap INLINE (instant on an empty table).
+--   * Large (> 1 GiB): arm an online cutover (empty shadow + AFTER INSERT mirror trigger for rows
+--     with created_at >= cutover, state='DUAL_WRITE'); the DATASET_FACETS_PARTITION_V1 backfill job
+--     copies history (created_at < cutover) and performs the count-verified swap off the startup path.
+--
+-- dataset_facets has no PRIMARY KEY (INSERT-only) and three FKs (dataset_uuid -> datasets,
+-- dataset_version_uuid -> dataset_versions, run_uuid -> runs), all restored at swap. Its only
+-- dependent is the trivial dataset_facets_view. namespace is denormalized from the run's
+-- namespace_name (the facet's producing run); NULL where run_uuid is NULL (HASH routes NULL to a
+-- fixed bucket). created_at is the app write-time Instant, the correct cutover boundary.
+
+-- 1. namespace column (nullable, instant).
+ALTER TABLE dataset_facets ADD COLUMN IF NOT EXISTS namespace TEXT;
+
+-- 2. Mirror trigger function (copies one row into the shadow, resolving namespace).
+CREATE OR REPLACE FUNCTION dataset_facets_mirror_to_partition() RETURNS trigger AS $$
+BEGIN
+    INSERT INTO dataset_facets_p (
+        created_at, dataset_uuid, dataset_version_uuid, run_uuid, lineage_event_time,
+        lineage_event_type, type, name, facet, namespace)
+    VALUES (
+        NEW.created_at, NEW.dataset_uuid, NEW.dataset_version_uuid, NEW.run_uuid,
+        NEW.lineage_event_time, NEW.lineage_event_type, NEW.type, NEW.name, NEW.facet,
+        COALESCE(NEW.namespace, (SELECT namespace_name FROM runs WHERE uuid = NEW.run_uuid)));
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 3. Empty partitioned shadow (same shape).
+CREATE TABLE IF NOT EXISTS dataset_facets_p (LIKE dataset_facets INCLUDING DEFAULTS INCLUDING INDEXES)
+    PARTITION BY RANGE (lineage_event_time);
+
+DO $$
+DECLARE
+    d     date := '2026-01-01';
+    mname text;
+    h     int;
+BEGIN
+    WHILE d < '2027-01-01' LOOP
+        mname := 'dataset_facets_p_y' || to_char(d, 'YYYY') || 'm' || to_char(d, 'MM');
+        EXECUTE format(
+            'CREATE TABLE IF NOT EXISTS %I PARTITION OF dataset_facets_p '
+            || 'FOR VALUES FROM (%L) TO (%L) PARTITION BY HASH (namespace)',
+            mname, d, (d + INTERVAL '1 month')::date);
+        FOR h IN 0..7 LOOP
+            EXECUTE format(
+                'CREATE TABLE IF NOT EXISTS %I PARTITION OF %I '
+                || 'FOR VALUES WITH (MODULUS 8, REMAINDER %s)',
+                mname || '_h' || h, mname, h);
+        END LOOP;
+        d := (d + INTERVAL '1 month')::date;
+    END LOOP;
+END $$;
+
+CREATE TABLE IF NOT EXISTS dataset_facets_p_default
+    PARTITION OF dataset_facets_p DEFAULT PARTITION BY HASH (namespace);
+DO $$
+DECLARE h int;
+BEGIN
+    FOR h IN 0..7 LOOP
+        EXECUTE format(
+            'CREATE TABLE IF NOT EXISTS dataset_facets_p_default_h%s '
+            || 'PARTITION OF dataset_facets_p_default FOR VALUES WITH (MODULUS 8, REMAINDER %s)',
+            h, h);
+    END LOOP;
+END $$;
+
+-- 4. Cutover state marker.
+CREATE TABLE IF NOT EXISTS dataset_facets_partition_state (
+    singleton  boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+    state      text        NOT NULL,
+    cutover_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 5. Size branch: small/empty -> inline swap now; large -> online (trigger + defer).
+DO $$
+DECLARE
+    v_bytes   bigint;
+    v_cutover timestamptz := clock_timestamp();
+BEGIN
+    v_bytes := pg_total_relation_size('dataset_facets');
+
+    IF v_bytes <= 1073741824 THEN
+        UPDATE dataset_facets df
+           SET namespace = r.namespace_name
+          FROM runs r
+         WHERE r.uuid = df.run_uuid AND df.namespace IS NULL;
+
+        INSERT INTO dataset_facets_p (
+            created_at, dataset_uuid, dataset_version_uuid, run_uuid, lineage_event_time,
+            lineage_event_type, type, name, facet, namespace)
+        SELECT created_at, dataset_uuid, dataset_version_uuid, run_uuid, lineage_event_time,
+               lineage_event_type, type, name, facet, namespace
+          FROM dataset_facets;
+
+        DROP VIEW IF EXISTS dataset_facets_view;
+        ALTER TABLE dataset_facets   RENAME TO dataset_facets_old;
+        ALTER TABLE dataset_facets_p RENAME TO dataset_facets;
+        ALTER TABLE dataset_facets ADD CONSTRAINT dataset_facets_dataset_uuid_fkey
+            FOREIGN KEY (dataset_uuid) REFERENCES datasets (uuid) ON DELETE CASCADE;
+        ALTER TABLE dataset_facets ADD CONSTRAINT dataset_facets_dataset_version_uuid_fkey
+            FOREIGN KEY (dataset_version_uuid) REFERENCES dataset_versions (uuid) ON DELETE CASCADE;
+        ALTER TABLE dataset_facets ADD CONSTRAINT dataset_facets_run_uuid_fkey
+            FOREIGN KEY (run_uuid) REFERENCES runs (uuid) ON DELETE CASCADE;
+        EXECUTE 'CREATE VIEW dataset_facets_view AS '
+             || 'SELECT created_at, dataset_uuid, dataset_version_uuid, run_uuid, lineage_event_time, '
+             || 'lineage_event_type, type, name, facet FROM dataset_facets';
+        DROP TABLE dataset_facets_old;
+
+        INSERT INTO dataset_facets_partition_state (singleton, state, cutover_at)
+             VALUES (true, 'SWAPPED', v_cutover)
+        ON CONFLICT (singleton) DO UPDATE SET state = 'SWAPPED', cutover_at = EXCLUDED.cutover_at;
+
+        RAISE NOTICE 'dataset_facets partitioned inline (% bytes <= 1 GiB).', v_bytes;
+    ELSE
+        EXECUTE format(
+            'CREATE TRIGGER dataset_facets_mirror_trg AFTER INSERT ON dataset_facets '
+            || 'FOR EACH ROW WHEN (NEW.created_at >= %L::timestamptz) '
+            || 'EXECUTE FUNCTION dataset_facets_mirror_to_partition()', v_cutover);
+
+        INSERT INTO dataset_facets_partition_state (singleton, state, cutover_at)
+             VALUES (true, 'DUAL_WRITE', v_cutover)
+        ON CONFLICT (singleton) DO UPDATE SET state = 'DUAL_WRITE', cutover_at = EXCLUDED.cutover_at;
+
+        RAISE NOTICE 'dataset_facets online cutover armed (% bytes > 1 GiB); DATASET_FACETS_PARTITION_V1 will copy + swap.', v_bytes;
+    END IF;
+END $$;

--- a/api/src/main/resources/marquez/db/migration/V112__partition_lineage_events.sql
+++ b/api/src/main/resources/marquez/db/migration/V112__partition_lineage_events.sql
@@ -1,0 +1,168 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- V112: Partition lineage_events by event time + job_namespace (online, startup-safe)
+--
+-- lineage_events is the raw event store (~730M rows / large JSONB over 2 years). Partition it with
+-- the composite scheme, HASH-keyed on the EXISTING job_namespace column (no new column needed):
+--   RANGE (event_time, monthly) -> HASH (job_namespace, 8) + hash-subpartitioned DEFAULT
+--
+-- Same size-branched online cutover as run_facets (V108) / dataset_facets (V111): inline swap when
+-- <= 1 GiB, otherwise a dual-write trigger + LINEAGE_EVENTS_PARTITION_V1 background copy + verified
+-- swap that never blocks startup. lineage_events has NO foreign keys. Its dependent is the actively
+-- refreshed matview lineage_events_by_type_hourly_view, dropped before the rename and recreated
+-- after (WITH NO DATA in the online path; the backfill job REFRESHes it once the swap commits).
+--
+-- Boundary: created_at (DEFAULT now() at UTC) is the write-time clock, so new rows are always
+-- non-null and >= cutover. Historical rows predating the created_at column may be NULL, so the
+-- backfill treats NULL as historical (created_at < cutover OR created_at IS NULL); the two sides
+-- stay disjoint and exactly-once.
+
+-- ============================================================================
+-- 1. Generalize the composite create helper to take the HASH column (V110 hardcoded 'namespace';
+--    lineage_events hashes on job_namespace). Runtime callers pass it explicitly.
+-- ============================================================================
+DROP FUNCTION IF EXISTS create_monthly_hash_partition(text, text, date, integer);
+
+CREATE OR REPLACE FUNCTION create_monthly_hash_partition(
+    parent_table text, partition_prefix text, start_date date, hash_modulus integer,
+    hash_column text)
+RETURNS void AS $$
+DECLARE
+    mname    text;
+    end_date date;
+    h        int;
+    lock_key bigint;
+BEGIN
+    start_date := date_trunc('month', start_date)::date;
+    end_date   := (start_date + INTERVAL '1 month')::date;
+    mname      := partition_prefix || '_y' || to_char(start_date, 'YYYY') || 'm' || to_char(start_date, 'MM');
+
+    lock_key := ('x' || substr(md5(mname), 1, 15))::bit(60)::bigint;
+    PERFORM pg_advisory_xact_lock(lock_key);
+
+    BEGIN
+        EXECUTE format(
+            'CREATE TABLE IF NOT EXISTS %I PARTITION OF %I '
+            || 'FOR VALUES FROM (%L) TO (%L) PARTITION BY HASH (%I)',
+            mname, parent_table, start_date, end_date, hash_column);
+
+        FOR h IN 0..(hash_modulus - 1) LOOP
+            EXECUTE format(
+                'CREATE TABLE IF NOT EXISTS %I PARTITION OF %I '
+                || 'FOR VALUES WITH (MODULUS %s, REMAINDER %s)',
+                mname || '_h' || h, mname, hash_modulus, h);
+        END LOOP;
+    EXCEPTION
+        WHEN OTHERS THEN
+            RAISE NOTICE 'Skipping partition % (already exists or overlaps): %', mname, SQLERRM;
+    END;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- 2. lineage_events online cutover
+-- ============================================================================
+
+-- Mirror trigger function: copy one row into the shadow (job_namespace already present).
+CREATE OR REPLACE FUNCTION lineage_events_mirror_to_partition() RETURNS trigger AS $$
+BEGIN
+    INSERT INTO lineage_events_p (
+        event_time, event, event_type, job_name, job_namespace, producer, run_uuid,
+        created_at, _event_type, run_date)
+    VALUES (
+        NEW.event_time, NEW.event, NEW.event_type, NEW.job_name, NEW.job_namespace, NEW.producer,
+        NEW.run_uuid, NEW.created_at, NEW._event_type, NEW.run_date);
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Empty partitioned shadow: RANGE(event_time) -> HASH(job_namespace).
+CREATE TABLE IF NOT EXISTS lineage_events_p (LIKE lineage_events INCLUDING DEFAULTS INCLUDING INDEXES)
+    PARTITION BY RANGE (event_time);
+
+DO $$
+DECLARE
+    d     date := '2026-01-01';
+    mname text;
+    h     int;
+BEGIN
+    WHILE d < '2027-01-01' LOOP
+        mname := 'lineage_events_p_y' || to_char(d, 'YYYY') || 'm' || to_char(d, 'MM');
+        EXECUTE format(
+            'CREATE TABLE IF NOT EXISTS %I PARTITION OF lineage_events_p '
+            || 'FOR VALUES FROM (%L) TO (%L) PARTITION BY HASH (job_namespace)',
+            mname, d, (d + INTERVAL '1 month')::date);
+        FOR h IN 0..7 LOOP
+            EXECUTE format(
+                'CREATE TABLE IF NOT EXISTS %I PARTITION OF %I '
+                || 'FOR VALUES WITH (MODULUS 8, REMAINDER %s)',
+                mname || '_h' || h, mname, h);
+        END LOOP;
+        d := (d + INTERVAL '1 month')::date;
+    END LOOP;
+END $$;
+
+CREATE TABLE IF NOT EXISTS lineage_events_p_default
+    PARTITION OF lineage_events_p DEFAULT PARTITION BY HASH (job_namespace);
+DO $$
+DECLARE h int;
+BEGIN
+    FOR h IN 0..7 LOOP
+        EXECUTE format(
+            'CREATE TABLE IF NOT EXISTS lineage_events_p_default_h%s '
+            || 'PARTITION OF lineage_events_p_default FOR VALUES WITH (MODULUS 8, REMAINDER %s)',
+            h, h);
+    END LOOP;
+END $$;
+
+CREATE TABLE IF NOT EXISTS lineage_events_partition_state (
+    singleton  boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+    state      text        NOT NULL,
+    cutover_at timestamptz NOT NULL DEFAULT now()
+);
+
+DO $$
+DECLARE
+    v_bytes   bigint;
+    v_cutover timestamptz := clock_timestamp();
+BEGIN
+    v_bytes := pg_total_relation_size('lineage_events');
+
+    IF v_bytes <= 1073741824 THEN
+        -- SMALL / EMPTY: copy + swap synchronously; recreate the matview WITH DATA (cheap when small).
+        INSERT INTO lineage_events_p (
+            event_time, event, event_type, job_name, job_namespace, producer, run_uuid,
+            created_at, _event_type, run_date)
+        SELECT event_time, event, event_type, job_name, job_namespace, producer, run_uuid,
+               created_at, _event_type, run_date
+          FROM lineage_events;
+
+        DROP MATERIALIZED VIEW IF EXISTS lineage_events_by_type_hourly_view;
+        ALTER TABLE lineage_events   RENAME TO lineage_events_old;
+        ALTER TABLE lineage_events_p RENAME TO lineage_events;
+        DROP TABLE lineage_events_old;
+        EXECUTE 'CREATE MATERIALIZED VIEW lineage_events_by_type_hourly_view AS '
+             || 'SELECT date_trunc(''hour'', event_time) AS start_interval, '
+             || 'count(*) FILTER (WHERE event_type = ''FAIL'') AS fail, '
+             || 'count(*) FILTER (WHERE event_type = ''START'') AS start, '
+             || 'count(*) FILTER (WHERE event_type = ''COMPLETE'') AS complete, '
+             || 'count(*) FILTER (WHERE event_type = ''ABORT'') AS abort '
+             || 'FROM lineage_events GROUP BY date_trunc(''hour'', event_time)';
+
+        INSERT INTO lineage_events_partition_state (singleton, state, cutover_at)
+             VALUES (true, 'SWAPPED', v_cutover)
+        ON CONFLICT (singleton) DO UPDATE SET state = 'SWAPPED', cutover_at = EXCLUDED.cutover_at;
+
+        RAISE NOTICE 'lineage_events partitioned inline (% bytes <= 1 GiB).', v_bytes;
+    ELSE
+        EXECUTE format(
+            'CREATE TRIGGER lineage_events_mirror_trg AFTER INSERT ON lineage_events '
+            || 'FOR EACH ROW WHEN (NEW.created_at >= %L::timestamptz) '
+            || 'EXECUTE FUNCTION lineage_events_mirror_to_partition()', v_cutover);
+
+        INSERT INTO lineage_events_partition_state (singleton, state, cutover_at)
+             VALUES (true, 'DUAL_WRITE', v_cutover)
+        ON CONFLICT (singleton) DO UPDATE SET state = 'DUAL_WRITE', cutover_at = EXCLUDED.cutover_at;
+
+        RAISE NOTICE 'lineage_events online cutover armed (% bytes > 1 GiB); LINEAGE_EVENTS_PARTITION_V1 will copy + swap.', v_bytes;
+    END IF;
+END $$;

--- a/api/src/test/java/marquez/common/api/LineageResourceV1V2ParityIT.java
+++ b/api/src/test/java/marquez/common/api/LineageResourceV1V2ParityIT.java
@@ -161,6 +161,47 @@ public class LineageResourceV1V2ParityIT extends BaseIntegrationTest {
   }
 
   @Test
+  public void testLineage_pipelineChain_v1AndV2_parity() throws Exception {
+    createNamespace(NAMESPACE_NAME);
+
+    // Five-job pipeline A -> B -> C -> D -> E. Each job reads the previous job's output:
+    //   chain_ds0 -[A]-> chain_ds1 -[B]-> chain_ds2 -[C]-> chain_ds3 -[D]-> chain_ds4 -[E]->
+    // chain_ds5
+    String[] jobs = {"chain_a", "chain_b", "chain_c", "chain_d", "chain_e"};
+    List<UUID> runIds = new ArrayList<>();
+    for (int i = 0; i < jobs.length; i++) {
+      UUID runId = UUID.randomUUID();
+      runIds.add(runId);
+      String in = "chain_ds" + i;
+      String out = "chain_ds" + (i + 1);
+      assertThat(
+              sendLineage(buildCompleteEvent(runId, NAMESPACE_NAME, jobs[i], in, out))
+                  .join()
+                  .statusCode())
+          .as("ingest %s", jobs[i])
+          .isEqualTo(201);
+    }
+    for (UUID runId : runIds) {
+      populateDenormalized(runId);
+    }
+
+    // Query depth=3 from the middle job C. V1 and V2 must return identical graphs — this is
+    // the regression guard for the UNION ALL CTE split, the tautology fix, and DISTINCT ON.
+    String nodeId = "job:" + NAMESPACE_NAME + ":chain_c";
+    HttpResponse<String> v1 = fetchLineage("/api/v1", nodeId, 3);
+    HttpResponse<String> v2 = fetchLineage("/api/v2", nodeId, 3);
+    assertThat(v1.statusCode()).as("V1 pipeline depth=3 status").isEqualTo(200);
+    assertThat(v2.statusCode()).as("V2 pipeline depth=3 status").isEqualTo(200);
+
+    assertThat(normalizeJson(mapper.readTree(v2.body())))
+        .as("V1 and V2 must agree on a 5-job pipeline at depth=3 from the middle node")
+        .isEqualTo(normalizeJson(mapper.readTree(v1.body())));
+
+    // The queried node must be present in the returned graph
+    assertThat(mapper.readTree(v2.body()).path("graph").findValuesAsText("id")).contains(nodeId);
+  }
+
+  @Test
   public void testLineage_missingNode_v1AndV2_bothReturn404() throws Exception {
     HttpResponse<String> v1 = fetchLineage("/api/v1", "job:never_existed_ns:never_existed_job", 2);
     HttpResponse<String> v2 = fetchLineage("/api/v2", "job:never_existed_ns:never_existed_job", 2);

--- a/api/src/test/java/marquez/db/migrations/V57_1__BackfillFacetsTest.java
+++ b/api/src/test/java/marquez/db/migrations/V57_1__BackfillFacetsTest.java
@@ -263,6 +263,12 @@ public class V57_1__BackfillFacetsTest {
       when(Jdbi.create(connection)).thenReturn(jdbi);
 
       // should be no data to import
+      // lineage_events is now a partitioned table (V112). An empty partitioned parent reports
+      // pg_class.reltuples = -1 until ANALYZEd (VACUUM alone does not roll up empty partitions),
+      // which makes V57.1's reltuples == 0 empty-check miss and skip the lock insert. ANALYZE so
+      // the
+      // estimate is 0 for the empty table, matching the pre-partition behavior this test asserts.
+      jdbi.useHandle(h -> h.execute("ANALYZE lineage_events"));
       subject.migrate(flywayContext);
 
       Instant lockCreatedAt =

--- a/api/src/test/java/marquez/jdbi/MarquezJdbiExternalPostgresExtension.java
+++ b/api/src/test/java/marquez/jdbi/MarquezJdbiExternalPostgresExtension.java
@@ -14,10 +14,25 @@ import org.testcontainers.containers.PostgreSQLContainer;
 
 public class MarquezJdbiExternalPostgresExtension extends JdbiExternalPostgresExtension {
 
-  private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15.4");
+  // Set MARQUEZ_TEST_PG_HOST to run the integration tests against an already-running PostgreSQL
+  // instead of a Testcontainers-managed one. This lets the suite run where Docker is unavailable
+  // (e.g. sandboxes / CI runners without a Docker daemon). Unset — the default, including CI —
+  // boots a throwaway postgres:15.4 container exactly as before. The target DB is CLEANed and
+  // re-migrated by Flyway on each test class, so point it at a dedicated throwaway database.
+  //   MARQUEZ_TEST_PG_HOST (enables external mode), MARQUEZ_TEST_PG_PORT (default 5432),
+  //   MARQUEZ_TEST_PG_DB (default marquez_test), MARQUEZ_TEST_PG_USER (default postgres),
+  //   MARQUEZ_TEST_PG_PASSWORD (default empty).
+  private static final String EXTERNAL_PG_HOST = System.getenv("MARQUEZ_TEST_PG_HOST");
+  private static final boolean USE_EXTERNAL_PG =
+      EXTERNAL_PG_HOST != null && !EXTERNAL_PG_HOST.isBlank();
+
+  private static final PostgreSQLContainer<?> POSTGRES =
+      USE_EXTERNAL_PG ? null : new PostgreSQLContainer<>("postgres:15.4");
 
   static {
-    POSTGRES.start();
+    if (!USE_EXTERNAL_PG) {
+      POSTGRES.start();
+    }
   }
 
   private final String hostname;
@@ -28,11 +43,19 @@ public class MarquezJdbiExternalPostgresExtension extends JdbiExternalPostgresEx
 
   public MarquezJdbiExternalPostgresExtension() {
     super();
-    hostname = POSTGRES.getHost();
-    port = POSTGRES.getMappedPort(5432);
-    username = POSTGRES.getUsername();
-    password = POSTGRES.getPassword();
-    database = POSTGRES.getDatabaseName();
+    if (USE_EXTERNAL_PG) {
+      hostname = EXTERNAL_PG_HOST;
+      port = Integer.parseInt(envOrDefault("MARQUEZ_TEST_PG_PORT", "5432"));
+      username = envOrDefault("MARQUEZ_TEST_PG_USER", "postgres");
+      password = envOrDefault("MARQUEZ_TEST_PG_PASSWORD", "");
+      database = envOrDefault("MARQUEZ_TEST_PG_DB", "marquez_test");
+    } else {
+      hostname = POSTGRES.getHost();
+      port = POSTGRES.getMappedPort(5432);
+      username = POSTGRES.getUsername();
+      password = POSTGRES.getPassword();
+      database = POSTGRES.getDatabaseName();
+    }
 
     // Add required plugins
     super.plugins.add(new SqlObjectPlugin());
@@ -42,6 +65,11 @@ public class MarquezJdbiExternalPostgresExtension extends JdbiExternalPostgresEx
     // Configure migration
     super.migration =
         Migration.before().withPaths("marquez/db/migration", "classpath:marquez/db/migrations");
+  }
+
+  private static String envOrDefault(String name, String fallback) {
+    String value = System.getenv(name);
+    return (value != null && !value.isBlank()) ? value : fallback;
   }
 
   @Override

--- a/api/src/test/java/marquez/jobs/backfill/DatasetFacetsPartitionBackfillJobTest.java
+++ b/api/src/test/java/marquez/jobs/backfill/DatasetFacetsPartitionBackfillJobTest.java
@@ -44,6 +44,11 @@ public class DatasetFacetsPartitionBackfillJobTest {
   public void testOnlineCutoverCopiesExactlyOnceAndSwaps() {
     jdbi.useHandle(
         h -> {
+          // Shared test DB: reset this version's checkpoint so the job runs fresh.
+          h.execute(
+              "DELETE FROM backfill_checkpoints WHERE version = '"
+                  + DatasetFacetsPartitionBackfillJob.VERSION
+                  + "'");
           h.execute("DROP VIEW IF EXISTS dataset_facets_view");
           h.execute("ALTER TABLE dataset_facets RENAME TO dataset_facets_p");
           h.execute("CREATE TABLE dataset_facets (LIKE dataset_facets_p INCLUDING DEFAULTS)");

--- a/api/src/test/java/marquez/jobs/backfill/DatasetFacetsPartitionBackfillJobTest.java
+++ b/api/src/test/java/marquez/jobs/backfill/DatasetFacetsPartitionBackfillJobTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2018-2024 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.jobs.backfill;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import marquez.api.JdbiUtils;
+import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
+import marquez.jobs.BackfillConfig;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Exercises the online (large-table) cutover path of {@link DatasetFacetsPartitionBackfillJob}:
+ * reshape dataset_facets into the DUAL_WRITE state V111 leaves on a large database, seed history +
+ * live (trigger-mirrored) rows, run the job, and assert it copies exactly-once and swaps (restoring
+ * all three FKs + the view).
+ */
+@ExtendWith(MarquezJdbiExternalPostgresExtension.class)
+public class DatasetFacetsPartitionBackfillJobTest {
+
+  private static Jdbi jdbi;
+  private static final UUID RUN = UUID.fromString("aaaaaaaa-0000-0000-0000-000000000001");
+  private static final String CUTOVER = "2026-06-01 00:00:00+00";
+
+  @BeforeAll
+  public static void setUpOnce(Jdbi jdbi) {
+    DatasetFacetsPartitionBackfillJobTest.jdbi = jdbi;
+  }
+
+  @AfterEach
+  public void tearDown(Jdbi jdbi) {
+    JdbiUtils.cleanDatabase(jdbi);
+  }
+
+  @Test
+  public void testOnlineCutoverCopiesExactlyOnceAndSwaps() {
+    jdbi.useHandle(
+        h -> {
+          h.execute("DROP VIEW IF EXISTS dataset_facets_view");
+          h.execute("ALTER TABLE dataset_facets RENAME TO dataset_facets_p");
+          h.execute("CREATE TABLE dataset_facets (LIKE dataset_facets_p INCLUDING DEFAULTS)");
+          h.execute(
+              "ALTER TABLE dataset_facets_p DROP CONSTRAINT IF EXISTS"
+                  + " dataset_facets_dataset_uuid_fkey");
+          h.execute(
+              "ALTER TABLE dataset_facets_p DROP CONSTRAINT IF EXISTS"
+                  + " dataset_facets_dataset_version_uuid_fkey");
+          h.execute(
+              "ALTER TABLE dataset_facets_p DROP CONSTRAINT IF EXISTS dataset_facets_run_uuid_fkey");
+
+          h.execute(
+              "INSERT INTO namespaces (uuid, created_at, updated_at, name, current_owner_name)"
+                  + " VALUES (gen_random_uuid(), now(), now(), 'nsX', 'owner') ON CONFLICT DO NOTHING");
+          h.execute(
+              "INSERT INTO runs (uuid, created_at, updated_at, current_run_state, namespace_name,"
+                  + " job_name, job_uuid) VALUES (?, now(), now(), 'COMPLETED', 'nsX', 'j',"
+                  + " gen_random_uuid())",
+              RUN);
+
+          // 700 historical rows (created_at < cutover); every other one NULL namespace.
+          h.execute(
+              "INSERT INTO dataset_facets (created_at, dataset_uuid, dataset_version_uuid, run_uuid,"
+                  + " lineage_event_time, lineage_event_type, type, name, facet, namespace)"
+                  + " SELECT '2026-05-01 00:00:00+00'::timestamptz + (g||' seconds')::interval, NULL,"
+                  + " NULL, ?, '2026-05-01'::timestamptz, 'COMPLETE', 'DATASET', 'df'||g, '{}'::jsonb,"
+                  + " CASE WHEN g % 2 = 0 THEN NULL ELSE 'nsX' END FROM generate_series(1,700) g",
+              RUN);
+
+          h.execute(
+              "CREATE TRIGGER dataset_facets_mirror_trg AFTER INSERT ON dataset_facets FOR EACH ROW"
+                  + " WHEN (NEW.created_at >= '"
+                  + CUTOVER
+                  + "'::timestamptz) EXECUTE FUNCTION dataset_facets_mirror_to_partition()");
+          h.execute(
+              "INSERT INTO dataset_facets_partition_state (singleton, state, cutover_at) VALUES"
+                  + " (true, 'DUAL_WRITE', '"
+                  + CUTOVER
+                  + "') ON CONFLICT (singleton) DO UPDATE SET state='DUAL_WRITE',"
+                  + " cutover_at=EXCLUDED.cutover_at");
+          h.execute(
+              "INSERT INTO dataset_facets (created_at, dataset_uuid, dataset_version_uuid, run_uuid,"
+                  + " lineage_event_time, lineage_event_type, type, name, facet, namespace)"
+                  + " SELECT '2026-06-02 00:00:00+00'::timestamptz + (g||' seconds')::interval, NULL,"
+                  + " NULL, ?, '2026-06-02'::timestamptz, 'COMPLETE', 'DATASET', 'dlive'||g,"
+                  + " '{}'::jsonb, 'nsX' FROM generate_series(1,30) g",
+              RUN);
+        });
+
+    BackfillConfig cfg = BackfillConfig.builder().batchSize(7).delayBetweenBatchesMs(0).build();
+    try {
+      new DatasetFacetsPartitionBackfillJob(jdbi, cfg).run();
+    } catch (Exception e) {
+      throw new AssertionError("cutover job threw: " + e.getMessage(), e);
+    }
+
+    jdbi.useHandle(
+        h -> {
+          assertThat(
+                  h.createQuery(
+                          "SELECT EXISTS(SELECT 1 FROM pg_partitioned_table WHERE partrelid ="
+                              + " 'dataset_facets'::regclass)")
+                      .mapTo(Boolean.class)
+                      .one())
+              .withFailMessage("dataset_facets should be partitioned")
+              .isTrue();
+          assertThat(h.createQuery("SELECT count(*) FROM dataset_facets").mapTo(Long.class).one())
+              .withFailMessage("all 700 historical + 30 live rows must survive exactly-once")
+              .isEqualTo(730L);
+          assertThat(
+                  h.createQuery("SELECT count(*) FROM dataset_facets WHERE namespace IS NULL")
+                      .mapTo(Long.class)
+                      .one())
+              .withFailMessage("NULL namespaces must be resolved during the copy")
+              .isEqualTo(0L);
+          assertThat(
+                  h.createQuery("SELECT state FROM dataset_facets_partition_state")
+                      .mapTo(String.class)
+                      .one())
+              .isEqualTo("SWAPPED");
+          assertThat(
+                  h.createQuery("SELECT to_regclass('dataset_facets_p') IS NULL")
+                      .mapTo(Boolean.class)
+                      .one())
+              .withFailMessage("shadow dataset_facets_p should be gone")
+              .isTrue();
+          assertThat(
+                  h.createQuery(
+                          "SELECT count(*)=0 FROM pg_trigger WHERE"
+                              + " tgname='dataset_facets_mirror_trg'")
+                      .mapTo(Boolean.class)
+                      .one())
+              .withFailMessage("mirror trigger should be dropped")
+              .isTrue();
+          assertThat(
+                  h.createQuery("SELECT to_regclass('dataset_facets_view') IS NOT NULL")
+                      .mapTo(Boolean.class)
+                      .one())
+              .withFailMessage("dataset_facets_view should be recreated")
+              .isTrue();
+          assertThat(
+                  h.createQuery(
+                          "SELECT count(*) FROM pg_constraint WHERE"
+                              + " conrelid='dataset_facets'::regclass AND contype='f'")
+                      .mapTo(Long.class)
+                      .one())
+              .withFailMessage("all three FKs should be restored on dataset_facets")
+              .isEqualTo(3L);
+        });
+  }
+}

--- a/api/src/test/java/marquez/jobs/backfill/LineageEventsPartitionBackfillJobTest.java
+++ b/api/src/test/java/marquez/jobs/backfill/LineageEventsPartitionBackfillJobTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2018-2024 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.jobs.backfill;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import marquez.api.JdbiUtils;
+import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
+import marquez.jobs.BackfillConfig;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Exercises the online (large-table) cutover path of {@link LineageEventsPartitionBackfillJob},
+ * covering the two lineage_events-specific concerns: pre-existing rows with NULL {@code created_at}
+ * (treated as historical), and the actively-refreshed matview {@code
+ * lineage_events_by_type_hourly_view} being dropped, recreated, and repopulated across the swap.
+ */
+@ExtendWith(MarquezJdbiExternalPostgresExtension.class)
+public class LineageEventsPartitionBackfillJobTest {
+
+  private static Jdbi jdbi;
+  private static final String CUTOVER = "2026-06-01 00:00:00+00";
+
+  @BeforeAll
+  public static void setUpOnce(Jdbi jdbi) {
+    LineageEventsPartitionBackfillJobTest.jdbi = jdbi;
+  }
+
+  @AfterEach
+  public void tearDown(Jdbi jdbi) {
+    JdbiUtils.cleanDatabase(jdbi);
+  }
+
+  @Test
+  public void testOnlineCutoverCopiesExactlyOnceWithNullBoundaryAndRefreshesMatview() {
+    jdbi.useHandle(
+        h -> {
+          h.execute("DROP MATERIALIZED VIEW IF EXISTS lineage_events_by_type_hourly_view");
+          h.execute("ALTER TABLE lineage_events RENAME TO lineage_events_p");
+          h.execute(
+              "CREATE TABLE lineage_events (LIKE lineage_events_p INCLUDING DEFAULTS INCLUDING"
+                  + " INDEXES)");
+
+          // 600 historical with created_at < cutover.
+          h.execute(
+              "INSERT INTO lineage_events (event_time, event, event_type, job_name, job_namespace,"
+                  + " producer, run_uuid, created_at, _event_type, run_date) SELECT '2026-05-01"
+                  + " 00:00:00+00'::timestamptz + (g||' seconds')::interval, '{}'::jsonb, 'COMPLETE',"
+                  + " 'j'||(g%3), 'ns'||(g%3), 'p', gen_random_uuid(), '2026-05-01"
+                  + " 00:00:00+00'::timestamptz + (g||' seconds')::interval, 'RUN_EVENT',"
+                  + " '2026-05-01' FROM generate_series(1,600) g");
+          // 200 historical with NULL created_at (predate the column).
+          h.execute(
+              "INSERT INTO lineage_events (event_time, event, event_type, job_name, job_namespace,"
+                  + " producer, run_uuid, created_at, _event_type, run_date) SELECT '2026-04-01"
+                  + " 00:00:00+00'::timestamptz + (g||' seconds')::interval, '{}'::jsonb, 'START',"
+                  + " 'j'||(g%3), 'ns'||(g%3), 'p', gen_random_uuid(), NULL, 'RUN_EVENT',"
+                  + " '2026-04-01' FROM generate_series(1,200) g");
+
+          h.execute(
+              "CREATE TRIGGER lineage_events_mirror_trg AFTER INSERT ON lineage_events FOR EACH ROW"
+                  + " WHEN (NEW.created_at >= '"
+                  + CUTOVER
+                  + "'::timestamptz) EXECUTE FUNCTION lineage_events_mirror_to_partition()");
+          h.execute(
+              "INSERT INTO lineage_events_partition_state (singleton, state, cutover_at) VALUES"
+                  + " (true, 'DUAL_WRITE', '"
+                  + CUTOVER
+                  + "') ON CONFLICT (singleton) DO UPDATE SET state='DUAL_WRITE',"
+                  + " cutover_at=EXCLUDED.cutover_at");
+          // 50 live rows (created_at >= cutover) mirrored by the trigger.
+          h.execute(
+              "INSERT INTO lineage_events (event_time, event, event_type, job_name, job_namespace,"
+                  + " producer, run_uuid, created_at, _event_type, run_date) SELECT '2026-06-02"
+                  + " 00:00:00+00'::timestamptz + (g||' seconds')::interval, '{}'::jsonb, 'COMPLETE',"
+                  + " 'j'||(g%3), 'ns'||(g%3), 'p', gen_random_uuid(), '2026-06-02"
+                  + " 00:00:00+00'::timestamptz + (g||' seconds')::interval, 'RUN_EVENT',"
+                  + " '2026-06-02' FROM generate_series(1,50) g");
+        });
+
+    BackfillConfig cfg = BackfillConfig.builder().batchSize(13).delayBetweenBatchesMs(0).build();
+    try {
+      new LineageEventsPartitionBackfillJob(jdbi, cfg).run();
+    } catch (Exception e) {
+      throw new AssertionError("cutover job threw: " + e.getMessage(), e);
+    }
+
+    jdbi.useHandle(
+        h -> {
+          assertThat(
+                  h.createQuery(
+                          "SELECT EXISTS(SELECT 1 FROM pg_partitioned_table WHERE partrelid ="
+                              + " 'lineage_events'::regclass)")
+                      .mapTo(Boolean.class)
+                      .one())
+              .withFailMessage("lineage_events should be partitioned")
+              .isTrue();
+          assertThat(h.createQuery("SELECT count(*) FROM lineage_events").mapTo(Long.class).one())
+              .withFailMessage(
+                  "all 800 historical (incl 200 NULL created_at) + 50 live must survive")
+              .isEqualTo(850L);
+          assertThat(
+                  h.createQuery("SELECT count(*) FROM lineage_events WHERE created_at IS NULL")
+                      .mapTo(Long.class)
+                      .one())
+              .withFailMessage("NULL created_at rows must be copied, not dropped")
+              .isEqualTo(200L);
+          assertThat(
+                  h.createQuery("SELECT state FROM lineage_events_partition_state")
+                      .mapTo(String.class)
+                      .one())
+              .isEqualTo("SWAPPED");
+          assertThat(
+                  h.createQuery("SELECT to_regclass('lineage_events_p') IS NULL")
+                      .mapTo(Boolean.class)
+                      .one())
+              .withFailMessage("shadow lineage_events_p should be gone")
+              .isTrue();
+          assertThat(
+                  h.createQuery(
+                          "SELECT count(*)=0 FROM pg_trigger WHERE"
+                              + " tgname='lineage_events_mirror_trg'")
+                      .mapTo(Boolean.class)
+                      .one())
+              .withFailMessage("mirror trigger should be dropped")
+              .isTrue();
+          // Matview recreated AND repopulated by afterSwapCommitted() — scannable + non-empty.
+          assertThat(
+                  h.createQuery("SELECT count(*) FROM lineage_events_by_type_hourly_view")
+                      .mapTo(Long.class)
+                      .one())
+              .withFailMessage("matview should be recreated and refreshed (populated)")
+              .isGreaterThan(0L);
+        });
+  }
+}

--- a/api/src/test/java/marquez/jobs/backfill/LineageEventsPartitionBackfillJobTest.java
+++ b/api/src/test/java/marquez/jobs/backfill/LineageEventsPartitionBackfillJobTest.java
@@ -42,6 +42,11 @@ public class LineageEventsPartitionBackfillJobTest {
   public void testOnlineCutoverCopiesExactlyOnceWithNullBoundaryAndRefreshesMatview() {
     jdbi.useHandle(
         h -> {
+          // Shared test DB: reset this version's checkpoint so the job runs fresh.
+          h.execute(
+              "DELETE FROM backfill_checkpoints WHERE version = '"
+                  + LineageEventsPartitionBackfillJob.VERSION
+                  + "'");
           h.execute("DROP MATERIALIZED VIEW IF EXISTS lineage_events_by_type_hourly_view");
           h.execute("ALTER TABLE lineage_events RENAME TO lineage_events_p");
           h.execute(

--- a/api/src/test/java/marquez/jobs/backfill/RunFacetsPartitionBackfillJobTest.java
+++ b/api/src/test/java/marquez/jobs/backfill/RunFacetsPartitionBackfillJobTest.java
@@ -215,5 +215,14 @@ public class RunFacetsPartitionBackfillJobTest {
                       .one())
               .isEqualTo("DUAL_WRITE");
         });
+
+    // Restore a clean, partitioned run_facets for the other tests sharing this DB: remove the
+    // injected orphan (fixing parity) and let the job finish the swap so no trigger/shadow leaks.
+    jdbi.useHandle(h -> h.execute("DELETE FROM run_facets_p WHERE name = 'orphan'"));
+    try {
+      new RunFacetsPartitionBackfillJob(jdbi, cfg).run();
+    } catch (Exception e) {
+      throw new AssertionError("cleanup swap failed: " + e.getMessage(), e);
+    }
   }
 }

--- a/api/src/test/java/marquez/jobs/backfill/RunFacetsPartitionBackfillJobTest.java
+++ b/api/src/test/java/marquez/jobs/backfill/RunFacetsPartitionBackfillJobTest.java
@@ -46,6 +46,12 @@ public class RunFacetsPartitionBackfillJobTest {
     // run_facets_p (no FK, as LIKE leaves it in V108), and a fresh plain run_facets holds history.
     jdbi.useHandle(
         h -> {
+          // Shared test DB: reset this version's checkpoint so the job actually runs (a prior
+          // cutover test may have marked it completed) and starts its keyset from the beginning.
+          h.execute(
+              "DELETE FROM backfill_checkpoints WHERE version = '"
+                  + RunFacetsPartitionBackfillJob.VERSION
+                  + "'");
           h.execute("DROP VIEW IF EXISTS run_facets_view");
           h.execute("ALTER TABLE run_facets RENAME TO run_facets_p");
           h.execute("CREATE TABLE run_facets (LIKE run_facets_p INCLUDING DEFAULTS)");
@@ -159,6 +165,12 @@ public class RunFacetsPartitionBackfillJobTest {
     // untouched (source of truth) rather than lose or corrupt data.
     jdbi.useHandle(
         h -> {
+          // Shared test DB: reset this version's checkpoint so the job actually runs (a prior
+          // cutover test may have marked it completed) and starts its keyset from the beginning.
+          h.execute(
+              "DELETE FROM backfill_checkpoints WHERE version = '"
+                  + RunFacetsPartitionBackfillJob.VERSION
+                  + "'");
           h.execute("DROP VIEW IF EXISTS run_facets_view");
           h.execute("ALTER TABLE run_facets RENAME TO run_facets_p");
           h.execute("CREATE TABLE run_facets (LIKE run_facets_p INCLUDING DEFAULTS)");

--- a/api/src/test/java/marquez/jobs/backfill/RunFacetsPartitionBackfillJobTest.java
+++ b/api/src/test/java/marquez/jobs/backfill/RunFacetsPartitionBackfillJobTest.java
@@ -6,6 +6,7 @@
 package marquez.jobs.backfill;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.UUID;
 import marquez.api.JdbiUtils;
@@ -148,6 +149,71 @@ public class RunFacetsPartitionBackfillJobTest {
           assertThat(triggerGone).withFailMessage("mirror trigger should be dropped").isTrue();
           assertThat(viewOk).withFailMessage("run_facets_view should be recreated").isTrue();
           assertThat(fkOnParent).withFailMessage("FK should be restored on run_facets").isTrue();
+        });
+  }
+
+  @Test
+  public void testCountMismatchAbortsSwapAndPreservesOldTable() {
+    // Arm the online cutover, then inject an extra shadow row with no counterpart in the old table
+    // so the post-copy count parity fails. The job must refuse to swap and leave the old table
+    // untouched (source of truth) rather than lose or corrupt data.
+    jdbi.useHandle(
+        h -> {
+          h.execute("DROP VIEW IF EXISTS run_facets_view");
+          h.execute("ALTER TABLE run_facets RENAME TO run_facets_p");
+          h.execute("CREATE TABLE run_facets (LIKE run_facets_p INCLUDING DEFAULTS)");
+          h.execute("ALTER TABLE run_facets_p DROP CONSTRAINT IF EXISTS run_facets_run_uuid_fkey");
+          h.execute(
+              "INSERT INTO namespaces (uuid, created_at, updated_at, name, current_owner_name)"
+                  + " VALUES (gen_random_uuid(), now(), now(), 'nsX', 'owner') ON CONFLICT DO NOTHING");
+          h.execute(
+              "INSERT INTO runs (uuid, created_at, updated_at, current_run_state, namespace_name,"
+                  + " job_name, job_uuid) VALUES (?, now(), now(), 'COMPLETED', 'nsX', 'j',"
+                  + " gen_random_uuid())",
+              RUN);
+          h.execute(
+              "INSERT INTO run_facets (created_at, run_uuid, lineage_event_time, lineage_event_type,"
+                  + " name, facet, namespace) SELECT '2026-05-01 00:00:00+00'::timestamptz +"
+                  + " (g||' seconds')::interval, ?, '2026-05-01'::timestamptz, 'COMPLETE', 'f'||g,"
+                  + " '{}'::jsonb, 'nsX' FROM generate_series(1,100) g",
+              RUN);
+          h.execute(
+              "INSERT INTO run_facets_partition_state (singleton, state, cutover_at) VALUES (true,"
+                  + " 'DUAL_WRITE', '"
+                  + CUTOVER
+                  + "') ON CONFLICT (singleton) DO UPDATE SET state='DUAL_WRITE',"
+                  + " cutover_at=EXCLUDED.cutover_at");
+          // Extra shadow row (not in old) -> after copy shadow=101, old=100 -> mismatch.
+          h.execute(
+              "INSERT INTO run_facets_p (created_at, run_uuid, lineage_event_time,"
+                  + " lineage_event_type, name, facet, namespace) VALUES ('2026-05-01', ?,"
+                  + " '2026-05-01', 'COMPLETE', 'orphan', '{}'::jsonb, 'nsX')",
+              RUN);
+        });
+
+    BackfillConfig cfg = BackfillConfig.builder().batchSize(7).delayBetweenBatchesMs(0).build();
+    assertThatThrownBy(() -> new RunFacetsPartitionBackfillJob(jdbi, cfg).run())
+        .hasMessageContaining("count mismatch");
+
+    // Old table preserved, unpartitioned, with all its rows; state still DUAL_WRITE (will retry).
+    jdbi.useHandle(
+        h -> {
+          assertThat(
+                  h.createQuery(
+                          "SELECT EXISTS(SELECT 1 FROM pg_partitioned_table WHERE partrelid ="
+                              + " 'run_facets'::regclass)")
+                      .mapTo(Boolean.class)
+                      .one())
+              .withFailMessage("run_facets must NOT be swapped on a count mismatch")
+              .isFalse();
+          assertThat(h.createQuery("SELECT count(*) FROM run_facets").mapTo(Long.class).one())
+              .withFailMessage("old table must be intact")
+              .isEqualTo(100L);
+          assertThat(
+                  h.createQuery("SELECT state FROM run_facets_partition_state")
+                      .mapTo(String.class)
+                      .one())
+              .isEqualTo("DUAL_WRITE");
         });
   }
 }

--- a/api/src/test/java/marquez/jobs/backfill/RunFacetsPartitionBackfillJobTest.java
+++ b/api/src/test/java/marquez/jobs/backfill/RunFacetsPartitionBackfillJobTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2018-2024 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.jobs.backfill;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import marquez.api.JdbiUtils;
+import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
+import marquez.jobs.BackfillConfig;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Exercises the online (large-table) cutover path of {@link RunFacetsPartitionBackfillJob}: reshape
+ * run_facets into the DUAL_WRITE state V108 leaves on a large database, seed history + live
+ * (trigger-mirrored) rows, run the job, and assert it copies exactly-once and swaps.
+ */
+@ExtendWith(MarquezJdbiExternalPostgresExtension.class)
+public class RunFacetsPartitionBackfillJobTest {
+
+  private static Jdbi jdbi;
+  private static final UUID RUN = UUID.fromString("aaaaaaaa-0000-0000-0000-000000000001");
+  private static final String CUTOVER = "2026-06-01 00:00:00+00";
+
+  @BeforeAll
+  public static void setUpOnce(Jdbi jdbi) {
+    RunFacetsPartitionBackfillJobTest.jdbi = jdbi;
+  }
+
+  @AfterEach
+  public void tearDown(Jdbi jdbi) {
+    JdbiUtils.cleanDatabase(jdbi);
+  }
+
+  @Test
+  public void testOnlineCutoverCopiesExactlyOnceAndSwaps() {
+    // Reshape into the large-path armed state: the partitioned table becomes the empty shadow
+    // run_facets_p (no FK, as LIKE leaves it in V108), and a fresh plain run_facets holds history.
+    jdbi.useHandle(
+        h -> {
+          h.execute("DROP VIEW IF EXISTS run_facets_view");
+          h.execute("ALTER TABLE run_facets RENAME TO run_facets_p");
+          h.execute("CREATE TABLE run_facets (LIKE run_facets_p INCLUDING DEFAULTS)");
+          h.execute("ALTER TABLE run_facets_p DROP CONSTRAINT IF EXISTS run_facets_run_uuid_fkey");
+
+          // A namespace + run so the copy's COALESCE(namespace, subselect on runs) resolves NULLs.
+          h.execute(
+              "INSERT INTO namespaces (uuid, created_at, updated_at, name, current_owner_name)"
+                  + " VALUES (gen_random_uuid(), now(), now(), 'nsX', 'owner') ON CONFLICT DO NOTHING");
+          h.execute(
+              "INSERT INTO runs (uuid, created_at, updated_at, current_run_state, namespace_name,"
+                  + " job_name, job_uuid) VALUES (?, now(), now(), 'COMPLETED', 'nsX', 'j',"
+                  + " gen_random_uuid())",
+              RUN);
+
+          // 900 historical rows (created_at < cutover); every other one has NULL namespace to force
+          // the subselect resolution during the copy.
+          h.execute(
+              "INSERT INTO run_facets (created_at, run_uuid, lineage_event_time, lineage_event_type,"
+                  + " name, facet, namespace) SELECT '2026-05-01 00:00:00+00'::timestamptz +"
+                  + " (g||' seconds')::interval, ?, '2026-05-01'::timestamptz, 'COMPLETE', 'f'||g,"
+                  + " '{}'::jsonb, CASE WHEN g % 2 = 0 THEN NULL ELSE 'nsX' END"
+                  + " FROM generate_series(1,900) g",
+              RUN);
+
+          // Arm dual-write (function created by V108) + marker, then 40 live rows the trigger
+          // mirrors.
+          h.execute(
+              "CREATE TRIGGER run_facets_mirror_trg AFTER INSERT ON run_facets FOR EACH ROW"
+                  + " WHEN (NEW.created_at >= '"
+                  + CUTOVER
+                  + "'::timestamptz) EXECUTE FUNCTION run_facets_mirror_to_partition()");
+          h.execute(
+              "INSERT INTO run_facets_partition_state (singleton, state, cutover_at) VALUES (true,"
+                  + " 'DUAL_WRITE', '"
+                  + CUTOVER
+                  + "') ON CONFLICT (singleton) DO UPDATE SET state='DUAL_WRITE',"
+                  + " cutover_at=EXCLUDED.cutover_at");
+          h.execute(
+              "INSERT INTO run_facets (created_at, run_uuid, lineage_event_time, lineage_event_type,"
+                  + " name, facet, namespace) SELECT '2026-06-02 00:00:00+00'::timestamptz +"
+                  + " (g||' seconds')::interval, ?, '2026-06-02'::timestamptz, 'COMPLETE',"
+                  + " 'live'||g, '{}'::jsonb, 'nsX' FROM generate_series(1,40) g",
+              RUN);
+        });
+
+    // Small batch size to exercise many keyset batches (the tid-vs-text ordering regression).
+    BackfillConfig cfg = BackfillConfig.builder().batchSize(7).delayBetweenBatchesMs(0).build();
+    try {
+      new RunFacetsPartitionBackfillJob(jdbi, cfg).run();
+    } catch (Exception e) {
+      throw new AssertionError("cutover job threw: " + e.getMessage(), e);
+    }
+
+    jdbi.useHandle(
+        h -> {
+          boolean partitioned =
+              h.createQuery(
+                      "SELECT EXISTS(SELECT 1 FROM pg_partitioned_table WHERE partrelid ="
+                          + " 'run_facets'::regclass)")
+                  .mapTo(Boolean.class)
+                  .one();
+          long count = h.createQuery("SELECT count(*) FROM run_facets").mapTo(Long.class).one();
+          long nullNs =
+              h.createQuery("SELECT count(*) FROM run_facets WHERE namespace IS NULL")
+                  .mapTo(Long.class)
+                  .one();
+          String state =
+              h.createQuery("SELECT state FROM run_facets_partition_state")
+                  .mapTo(String.class)
+                  .one();
+          boolean shadowGone =
+              h.createQuery("SELECT to_regclass('run_facets_p') IS NULL")
+                  .mapTo(Boolean.class)
+                  .one();
+          boolean triggerGone =
+              h.createQuery(
+                      "SELECT count(*)=0 FROM pg_trigger WHERE tgname='run_facets_mirror_trg'")
+                  .mapTo(Boolean.class)
+                  .one();
+          boolean viewOk =
+              h.createQuery("SELECT to_regclass('run_facets_view') IS NOT NULL")
+                  .mapTo(Boolean.class)
+                  .one();
+          boolean fkOnParent =
+              h.createQuery(
+                      "SELECT count(*)=1 FROM pg_constraint WHERE conname='run_facets_run_uuid_fkey'"
+                          + " AND conrelid='run_facets'::regclass")
+                  .mapTo(Boolean.class)
+                  .one();
+
+          assertThat(partitioned).withFailMessage("run_facets should be partitioned").isTrue();
+          assertThat(count)
+              .withFailMessage("all 900 historical + 40 live rows must survive exactly-once")
+              .isEqualTo(940L);
+          assertThat(nullNs)
+              .withFailMessage("NULL namespaces must be resolved from runs during the copy")
+              .isEqualTo(0L);
+          assertThat(state).isEqualTo("SWAPPED");
+          assertThat(shadowGone).withFailMessage("shadow run_facets_p should be gone").isTrue();
+          assertThat(triggerGone).withFailMessage("mirror trigger should be dropped").isTrue();
+          assertThat(viewOk).withFailMessage("run_facets_view should be recreated").isTrue();
+          assertThat(fkOnParent).withFailMessage("FK should be restored on run_facets").isTrue();
+        });
+  }
+}

--- a/api/src/test/java/marquez/service/DenormalizedLineageServiceTest.java
+++ b/api/src/test/java/marquez/service/DenormalizedLineageServiceTest.java
@@ -243,27 +243,29 @@ public class DenormalizedLineageServiceTest {
               handle
                   .createUpdate(
                       "INSERT INTO lineage_edges (from_node_id, from_type, to_node_id, to_type,"
-                          + " edge_type, run_uuid, run_date, created_at) "
+                          + " edge_type, namespace, run_uuid, run_date, created_at) "
                           + "SELECT rim.dataset_version_uuid, 'dataset_version', r.uuid, 'run',"
-                          + " 'CONSUMES', r.uuid,"
+                          + " 'CONSUMES', r.namespace_name, r.uuid,"
                           + " DATE(COALESCE(r.ended_at, r.started_at, r.created_at)), NOW() "
                           + "FROM runs_input_mapping rim INNER JOIN runs r ON r.uuid = rim.run_uuid "
                           + "WHERE r.current_run_state IN ('COMPLETED', 'FAILED', 'ABORTED') "
-                          + "ON CONFLICT (from_node_id, to_node_id, edge_type) DO NOTHING")
+                          + "ON CONFLICT (from_node_id, to_node_id, edge_type, run_date, namespace)"
+                          + " DO NOTHING")
                   .execute();
 
           int produces =
               handle
                   .createUpdate(
                       "INSERT INTO lineage_edges (from_node_id, from_type, to_node_id, to_type,"
-                          + " edge_type, run_uuid, run_date, created_at) "
+                          + " edge_type, namespace, run_uuid, run_date, created_at) "
                           + "SELECT dv.run_uuid, 'run', dv.uuid, 'dataset_version', 'PRODUCES',"
-                          + " dv.run_uuid,"
+                          + " r.namespace_name, dv.run_uuid,"
                           + " DATE(COALESCE(r.ended_at, r.started_at, r.created_at)), NOW() "
                           + "FROM dataset_versions dv INNER JOIN runs r ON r.uuid = dv.run_uuid "
                           + "WHERE dv.run_uuid IS NOT NULL"
                           + " AND r.current_run_state IN ('COMPLETED', 'FAILED', 'ABORTED') "
-                          + "ON CONFLICT (from_node_id, to_node_id, edge_type) DO NOTHING")
+                          + "ON CONFLICT (from_node_id, to_node_id, edge_type, run_date, namespace)"
+                          + " DO NOTHING")
                   .execute();
 
           assertThat(consumes + produces)

--- a/api/src/test/java/marquez/service/DenormalizedLineageServiceTest.java
+++ b/api/src/test/java/marquez/service/DenormalizedLineageServiceTest.java
@@ -49,6 +49,7 @@ public class DenormalizedLineageServiceTest {
     // Clean up denormalized tables after each test
     jdbi.useHandle(
         handle -> {
+          handle.execute("DELETE FROM lineage_edges");
           handle.execute("DELETE FROM run_lineage_denormalized");
           handle.execute("DELETE FROM run_parent_lineage_denormalized");
           handle.execute("DELETE FROM job_denormalized");
@@ -142,6 +143,138 @@ public class DenormalizedLineageServiceTest {
                   .mapTo(Long.class)
                   .one();
           assertThat(runLineageCount).isEqualTo(1);
+        });
+  }
+
+  @Test
+  public void testLineageEdgesPopulatedForCompletedRun() {
+    // A COMPLETE run with one input and one output dataset must produce exactly:
+    //   - one CONSUMES edge: input dataset_version -> run
+    //   - one PRODUCES edge: run -> output dataset_version
+    UpdateLineageRow lineageRow =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "edges_complete_job",
+            "COMPLETE",
+            JobFacet.builder().build(),
+            List.of(new Dataset("namespace", "edges_input", null)),
+            List.of(new Dataset("namespace", "edges_output", null)));
+    UUID runUuid = lineageRow.getRun().getUuid();
+
+    // Guard for the V107 backfill bug: a COMPLETE OpenLineage event must land as the
+    // Marquez RunState 'COMPLETED'. The backfill filters current_run_state IN ('COMPLETED', ...);
+    // if the stored token were 'COMPLETE' the historical backfill would skip every completed run.
+    jdbi.useHandle(
+        handle -> {
+          String state =
+              handle
+                  .createQuery("SELECT current_run_state FROM runs WHERE uuid = ?")
+                  .bind(0, runUuid)
+                  .mapTo(String.class)
+                  .one();
+          assertThat(state).isEqualTo("COMPLETED");
+        });
+
+    // When: populate denormalized lineage (this also writes lineage_edges)
+    denormalizedLineageService.populateLineageForRun(runUuid);
+
+    // Then: exactly one CONSUMES edge into the run and one PRODUCES edge out of the run
+    jdbi.useHandle(
+        handle -> {
+          Long consumes =
+              handle
+                  .createQuery(
+                      "SELECT COUNT(*) FROM lineage_edges WHERE to_node_id = ? AND edge_type = 'CONSUMES'")
+                  .bind(0, runUuid)
+                  .mapTo(Long.class)
+                  .one();
+          assertThat(consumes)
+              .withFailMessage("expected one CONSUMES edge (input dataset_version -> run)")
+              .isEqualTo(1);
+
+          Long produces =
+              handle
+                  .createQuery(
+                      "SELECT COUNT(*) FROM lineage_edges WHERE from_node_id = ? AND edge_type = 'PRODUCES'")
+                  .bind(0, runUuid)
+                  .mapTo(Long.class)
+                  .one();
+          assertThat(produces)
+              .withFailMessage("expected one PRODUCES edge (run -> output dataset_version)")
+              .isEqualTo(1);
+        });
+
+    // And: idempotent — re-running must not duplicate edges (ON CONFLICT DO NOTHING)
+    denormalizedLineageService.populateLineageForRun(runUuid);
+    jdbi.useHandle(
+        handle -> {
+          Long total =
+              handle
+                  .createQuery("SELECT COUNT(*) FROM lineage_edges WHERE run_uuid = ?")
+                  .bind(0, runUuid)
+                  .mapTo(Long.class)
+                  .one();
+          assertThat(total)
+              .withFailMessage("re-running populateLineageForRun must not duplicate edges")
+              .isEqualTo(2);
+        });
+  }
+
+  @Test
+  public void testLineageEdgesBackfillMatchesCompletedRuns() {
+    // Faithful regression test for the V107 backfill: a COMPLETED run must be picked up.
+    // The migration filtered current_run_state IN ('COMPLETED', 'FAILED', 'ABORTED').
+    // With the prior 'COMPLETE' token this backfill matched zero completed runs and the
+    // assertion below would fail with a count of 0.
+    LineageTestUtils.createLineageRow(
+        openLineageDao,
+        "backfill_job",
+        "COMPLETE",
+        JobFacet.builder().build(),
+        List.of(new Dataset("namespace", "backfill_input", null)),
+        List.of(new Dataset("namespace", "backfill_output", null)));
+
+    jdbi.useHandle(
+        handle -> {
+          // Measure the backfill in isolation from any live-path edges.
+          handle.execute("DELETE FROM lineage_edges");
+
+          int consumes =
+              handle
+                  .createUpdate(
+                      "INSERT INTO lineage_edges (from_node_id, from_type, to_node_id, to_type,"
+                          + " edge_type, run_uuid, run_date, created_at) "
+                          + "SELECT rim.dataset_version_uuid, 'dataset_version', r.uuid, 'run',"
+                          + " 'CONSUMES', r.uuid,"
+                          + " DATE(COALESCE(r.ended_at, r.started_at, r.created_at)), NOW() "
+                          + "FROM runs_input_mapping rim INNER JOIN runs r ON r.uuid = rim.run_uuid "
+                          + "WHERE r.current_run_state IN ('COMPLETED', 'FAILED', 'ABORTED') "
+                          + "ON CONFLICT (from_node_id, to_node_id, edge_type) DO NOTHING")
+                  .execute();
+
+          int produces =
+              handle
+                  .createUpdate(
+                      "INSERT INTO lineage_edges (from_node_id, from_type, to_node_id, to_type,"
+                          + " edge_type, run_uuid, run_date, created_at) "
+                          + "SELECT dv.run_uuid, 'run', dv.uuid, 'dataset_version', 'PRODUCES',"
+                          + " dv.run_uuid,"
+                          + " DATE(COALESCE(r.ended_at, r.started_at, r.created_at)), NOW() "
+                          + "FROM dataset_versions dv INNER JOIN runs r ON r.uuid = dv.run_uuid "
+                          + "WHERE dv.run_uuid IS NOT NULL"
+                          + " AND r.current_run_state IN ('COMPLETED', 'FAILED', 'ABORTED') "
+                          + "ON CONFLICT (from_node_id, to_node_id, edge_type) DO NOTHING")
+                  .execute();
+
+          assertThat(consumes + produces)
+              .withFailMessage(
+                  "V107 backfill must insert edges for COMPLETED runs; a count of 0 means the"
+                      + " current_run_state filter token is wrong")
+              .isGreaterThan(0);
+
+          Long total =
+              handle.createQuery("SELECT COUNT(*) FROM lineage_edges").mapTo(Long.class).one();
+          assertThat(total).isGreaterThan(0);
         });
   }
 

--- a/api/src/test/java/marquez/service/LineageServiceTest.java
+++ b/api/src/test/java/marquez/service/LineageServiceTest.java
@@ -837,6 +837,64 @@ public class LineageServiceTest {
   }
 
   @Test
+  public void testJobLineage_edgeBfs_matchesRecursiveCte() {
+    // Same chain A -> jd1 -> B -> jd2 -> C as the run test, but queried from a JOB node. Two jobs
+    // are adjacent when they share ANY dataset, so B reaches A (via jd1) and C (via jd2) at depth
+    // 1.
+    UpdateLineageRow a =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "jbfs_a",
+            "COMPLETE",
+            jobFacet,
+            List.of(new Dataset(NAMESPACE, "jbfs_d0", null)),
+            List.of(new Dataset(NAMESPACE, "jbfs_d1", null)));
+    UpdateLineageRow b =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "jbfs_b",
+            "COMPLETE",
+            jobFacet,
+            List.of(new Dataset(NAMESPACE, "jbfs_d1", null)),
+            List.of(new Dataset(NAMESPACE, "jbfs_d2", null)));
+    UpdateLineageRow c =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "jbfs_c",
+            "COMPLETE",
+            jobFacet,
+            List.of(new Dataset(NAMESPACE, "jbfs_d2", null)),
+            List.of(new Dataset(NAMESPACE, "jbfs_d3", null)));
+
+    // Populate denormalized tables AND lineage_edges (incl. job<->dataset edges) for each run.
+    for (UUID runUuid : List.of(a.getRun().getUuid(), b.getRun().getUuid(), c.getRun().getUuid())) {
+      denormalizedLineageService.populateLineageForRun(runUuid);
+    }
+
+    LineageService bfsService =
+        new LineageService(
+            lineageDao, jdbi.onDemand(JobDao.class), jdbi.onDemand(RunDao.class), true);
+
+    NodeId middleJob = NodeId.of(new NamespaceName(NAMESPACE), new JobName("jbfs_b"));
+    for (int depth : new int[] {1, 2, 5}) {
+      Lineage viaCte = lineageService.lineage(middleJob, depth, false);
+      Lineage viaBfs = bfsService.lineage(middleJob, depth, false);
+
+      java.util.Set<NodeId> cteNodes =
+          viaCte.getGraph().stream().map(Node::getId).collect(Collectors.toSet());
+      java.util.Set<NodeId> bfsNodes =
+          viaBfs.getGraph().stream().map(Node::getId).collect(Collectors.toSet());
+
+      assertThat(bfsNodes)
+          .withFailMessage(
+              "job lineage_edges BFS must return the same node set as the recursive CTE at depth"
+                  + " %d: cte=%s bfs=%s",
+              depth, cteNodes, bfsNodes)
+          .isEqualTo(cteNodes);
+    }
+  }
+
+  @Test
   public void testParentRunLineage() {
     // Create parent run
     UpdateLineageRow parentRun =

--- a/api/src/test/java/marquez/service/LineageServiceTest.java
+++ b/api/src/test/java/marquez/service/LineageServiceTest.java
@@ -779,6 +779,64 @@ public class LineageServiceTest {
   }
 
   @Test
+  public void testRunLineage_edgeBfs_matchesRecursiveCte() {
+    // Build a chain A -> d1 -> B -> d2 -> C -> d3 so the middle run B has both an
+    // upstream (A) and downstream (C) neighbour at depth 1, and A/C reach further at depth 2.
+    UpdateLineageRow a =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "bfs_a",
+            "COMPLETE",
+            jobFacet,
+            List.of(new Dataset(NAMESPACE, "bfs_d0", null)),
+            List.of(new Dataset(NAMESPACE, "bfs_d1", null)));
+    UpdateLineageRow b =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "bfs_b",
+            "COMPLETE",
+            jobFacet,
+            List.of(new Dataset(NAMESPACE, "bfs_d1", null)),
+            List.of(new Dataset(NAMESPACE, "bfs_d2", null)));
+    UpdateLineageRow c =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "bfs_c",
+            "COMPLETE",
+            jobFacet,
+            List.of(new Dataset(NAMESPACE, "bfs_d2", null)),
+            List.of(new Dataset(NAMESPACE, "bfs_d3", null)));
+
+    // Populate denormalized tables AND lineage_edges for each run.
+    for (UUID runUuid : List.of(a.getRun().getUuid(), b.getRun().getUuid(), c.getRun().getUuid())) {
+      denormalizedLineageService.populateLineageForRun(runUuid);
+    }
+
+    // A second service that reads via the lineage_edges BFS path.
+    LineageService bfsService =
+        new LineageService(
+            lineageDao, jdbi.onDemand(JobDao.class), jdbi.onDemand(RunDao.class), true);
+
+    NodeId middle = NodeId.of(new RunId(b.getRun().getUuid()));
+    for (int depth : new int[] {1, 2, 5}) {
+      Lineage viaCte = lineageService.lineage(middle, depth, false);
+      Lineage viaBfs = bfsService.lineage(middle, depth, false);
+
+      java.util.Set<NodeId> cteNodes =
+          viaCte.getGraph().stream().map(Node::getId).collect(Collectors.toSet());
+      java.util.Set<NodeId> bfsNodes =
+          viaBfs.getGraph().stream().map(Node::getId).collect(Collectors.toSet());
+
+      assertThat(bfsNodes)
+          .withFailMessage(
+              "lineage_edges BFS must return the same node set as the recursive CTE at depth %d:"
+                  + " cte=%s bfs=%s",
+              depth, cteNodes, bfsNodes)
+          .isEqualTo(cteNodes);
+    }
+  }
+
+  @Test
   public void testParentRunLineage() {
     // Create parent run
     UpdateLineageRow parentRun =

--- a/api/src/test/java/marquez/service/OpenLineageServiceIntegrationTest.java
+++ b/api/src/test/java/marquez/service/OpenLineageServiceIntegrationTest.java
@@ -419,6 +419,52 @@ public class OpenLineageServiceIntegrationTest {
   }
 
   @Test
+  void testAbortEventTriggersTerminalDenormalization()
+      throws ExecutionException, InterruptedException {
+    // OpenLineage emits the event type ABORT (not ABORTED). The denorm write gating must
+    // recognize ABORT as terminal. We send an ABORT event with NO datasets: with no datasets
+    // and a non-START event, the entity-denorm gate fires ONLY when the event is terminal,
+    // so job_denormalized is populated only if ABORT is correctly treated as terminal.
+    String abortJobName = "abort_terminal_job";
+    UUID runId = UUID.randomUUID();
+
+    lineageService
+        .createAsync(
+            LineageEvent.builder()
+                .eventType("ABORT")
+                .run(new LineageEvent.Run(runId.toString(), RunFacet.builder().build()))
+                .job(LineageEvent.Job.builder().name(abortJobName).namespace(NAMESPACE).build())
+                .eventTime(Instant.now().atZone(TIMEZONE))
+                .inputs(Collections.emptyList())
+                .outputs(Collections.emptyList())
+                .build())
+        .get();
+
+    // The entity-denorm write runs inside the awaited future (unlike the fire-and-forget lineage
+    // populate), so this assertion is deterministic.
+    UUID jobUuid =
+        jdbi.withHandle(
+            h ->
+                h.createQuery("SELECT uuid FROM jobs WHERE name = ? AND namespace_name = ?")
+                    .bind(0, abortJobName)
+                    .bind(1, NAMESPACE)
+                    .mapTo(UUID.class)
+                    .one());
+
+    Long denormCount =
+        jdbi.withHandle(
+            h ->
+                h.createQuery("SELECT COUNT(*) FROM job_denormalized WHERE uuid = ?")
+                    .bind(0, jobUuid)
+                    .mapTo(Long.class)
+                    .one());
+    assertThat(denormCount)
+        .withFailMessage(
+            "ABORT must be treated as terminal and populate job_denormalized for a no-dataset run")
+        .isEqualTo(1L);
+  }
+
+  @Test
   void testJobIsNotHiddenAfterSubsequentOLEvent() throws ExecutionException, InterruptedException {
     String name = "aNotHiddenJob";
 

--- a/api/src/test/java/marquez/service/PartitionManagementServiceTest.java
+++ b/api/src/test/java/marquez/service/PartitionManagementServiceTest.java
@@ -269,4 +269,96 @@ public class PartitionManagementServiceTest {
           log.info("Successfully verified date range for partition: {}", partitionName);
         });
   }
+
+  @Test
+  public void testEnsureCompositePartitionExists() {
+    // Given: a future month with no pre-created partition (V107/V108 only seed 2026).
+    LocalDate testDate = LocalDate.of(2030, 9, 15);
+
+    // When: we provision the composite RANGE->HASH subtree.
+    assertThatCode(() -> partitionManagementService.ensureCompositePartitionExists(testDate))
+        .doesNotThrowAnyException();
+    // And re-run to confirm idempotency.
+    assertThatCode(() -> partitionManagementService.ensureCompositePartitionExists(testDate))
+        .doesNotThrowAnyException();
+
+    // Then: each parent has the month partition + its 8 hash sub-partitions, and the
+    // sub-partitions inherit the parent's indexes (no per-partition index DDL in V110).
+    jdbi.useHandle(
+        handle -> {
+          for (String[] tbl :
+              new String[][] {{"lineage_edges", "lineage_edges"}, {"run_facets", "run_facets_p"}}) {
+            String month = tbl[1] + "_y2030m09";
+            Long hashChildren =
+                handle
+                    .createQuery("SELECT COUNT(*) FROM pg_inherits WHERE inhparent = :m::regclass")
+                    .bind("m", month)
+                    .mapTo(Long.class)
+                    .one();
+            assertThat(hashChildren)
+                .withFailMessage(
+                    "%s should have 8 hash sub-partitions, had %s", month, hashChildren)
+                .isEqualTo(8);
+
+            Long idxOnChild =
+                handle
+                    .createQuery("SELECT COUNT(*) FROM pg_index WHERE indrelid = :c::regclass")
+                    .bind("c", month + "_h0")
+                    .mapTo(Long.class)
+                    .one();
+            assertThat(idxOnChild)
+                .withFailMessage("%s_h0 should inherit the parent's indexes", month)
+                .isGreaterThanOrEqualTo(3);
+          }
+          log.info("Successfully verified composite partition creation for 2030-09");
+        });
+  }
+
+  @Test
+  public void testCleanupOldCompositePartitions() {
+    // Given: a clearly out-of-retention month (2020-01) and an in-window month (current month)
+    // for both composite tables.
+    LocalDate oldMonth = LocalDate.of(2020, 1, 1);
+    LocalDate recentMonth = LocalDate.now().withDayOfMonth(1);
+    partitionManagementService.ensureCompositePartitionExists(oldMonth);
+    partitionManagementService.ensureCompositePartitionExists(recentMonth);
+
+    // When: retention cleanup runs (lineage_edges 24mo, run_facets 12mo — both far past 2020).
+    assertThatCode(() -> partitionManagementService.cleanupOldCompositePartitions())
+        .doesNotThrowAnyException();
+
+    // Then: the 2020 month (and its hash children, via CASCADE) is gone for both tables, while the
+    // recent month and the DEFAULT safety-net partition survive.
+    jdbi.useHandle(
+        handle -> {
+          String recentSuffix =
+              String.format(
+                  "_y%04dm%02d", recentMonth.getYear(), recentMonth.getMonthValue()); // _y2026m06
+          for (String[] tbl :
+              new String[][] {{"lineage_edges", "lineage_edges"}, {"run_facets", "run_facets_p"}}) {
+            String prefix = tbl[1];
+            assertThat(regclassExists(handle, prefix + "_y2020m01"))
+                .withFailMessage("%s_y2020m01 should have been dropped by retention", prefix)
+                .isFalse();
+            assertThat(regclassExists(handle, prefix + "_y2020m01_h0"))
+                .withFailMessage("%s_y2020m01_h0 should be CASCADE-dropped with its month", prefix)
+                .isFalse();
+            assertThat(regclassExists(handle, prefix + recentSuffix))
+                .withFailMessage("%s%s (in retention window) should survive", prefix, recentSuffix)
+                .isTrue();
+            assertThat(regclassExists(handle, prefix + "_default"))
+                .withFailMessage("%s_default safety-net partition must never be dropped", prefix)
+                .isTrue();
+          }
+          log.info("Successfully verified composite retention cleanup");
+        });
+  }
+
+  private static boolean regclassExists(org.jdbi.v3.core.Handle handle, String relName) {
+    return handle
+        .createQuery("SELECT to_regclass(:n) IS NOT NULL")
+        .bind("n", relName)
+        .mapTo(Boolean.class)
+        .one();
+  }
 }

--- a/chart/ci/ci-values.yaml
+++ b/chart/ci/ci-values.yaml
@@ -6,3 +6,16 @@ postgresql:
     registry: docker.io
     repository: bitnamilegacy/postgresql
     tag: "17.2.0-debian-12-r1"
+
+## CI resource overrides — kind cluster on ubuntu-latest has 2 vCPU / 7 GB RAM total.
+## Production values (cpu: "2" req / "4" limit, memory: "5Gi" req / "8Gi" limit) would
+## make the Marquez pod unschedulable in the shared kind node. Use minimal sizing here.
+marquez:
+  javaOpts: "-Xms256m -Xmx512m -XX:+ExitOnOutOfMemoryError"
+  resources:
+    limits:
+      cpu: "1"
+      memory: "768Mi"
+    requests:
+      cpu: "250m"
+      memory: "384Mi"

--- a/chart/templates/marquez/configmap.yaml
+++ b/chart/templates/marquez/configmap.yaml
@@ -37,15 +37,10 @@ data:
       url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=${POSTGRES_SSL_MODE:-prefer}&prepareThreshold=${PGBOUNCER_PREPARE_THRESHOLD:-0}
       user: ${POSTGRES_USER}
       password: ${POSTGRES_PASSWORD}
-      # HikariCP connection pool — sized for 3 API replicas × 10 connections each = 30 backend connections
-      # PgBouncer sits in front and fans out to PostgreSQL with its own pool
       maxSize: ${DB_POOL_MAX_SIZE:-20}
       minSize: ${DB_POOL_MIN_SIZE:-5}
       maxWaitForConnection: 5s
       validationQuery: "SELECT 1"
-      connectionTimeout: 5000
-      idleTimeout: 600000
-      maxLifetime: 1800000
     # Enables retention policy configuration for database (default: disabled)
     {{- if .Values.marquez.dbRetention }}
     dbRetention:

--- a/chart/templates/marquez/configmap.yaml
+++ b/chart/templates/marquez/configmap.yaml
@@ -34,7 +34,7 @@ data:
     db:
       driverClass: org.postgresql.Driver
       # Add prepareThreshold=0 when PGBOUNCER_ENABLED=true (transaction mode requires no server-side prepared stmts)
-      url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=${POSTGRES_SSL_MODE:-require}&prepareThreshold=${PGBOUNCER_PREPARE_THRESHOLD:-0}
+      url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=${POSTGRES_SSL_MODE:-prefer}&prepareThreshold=${PGBOUNCER_PREPARE_THRESHOLD:-0}
       user: ${POSTGRES_USER}
       password: ${POSTGRES_PASSWORD}
       # HikariCP connection pool — sized for 3 API replicas × 10 connections each = 30 backend connections
@@ -64,7 +64,7 @@ data:
         - type: console
           logFormat: "%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n"
       loggers:
-        marquez: INFO
+        marquez: ${LOG_LEVEL:-WARN}
         marquez.db: WARN
         org.jdbi: WARN
         org.postgresql: WARN

--- a/chart/templates/marquez/configmap.yaml
+++ b/chart/templates/marquez/configmap.yaml
@@ -34,7 +34,7 @@ data:
     db:
       driverClass: org.postgresql.Driver
       # Add prepareThreshold=0 when PGBOUNCER_ENABLED=true (transaction mode requires no server-side prepared stmts)
-      url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=${POSTGRES_SSL_MODE:-prefer}&prepareThreshold=${PGBOUNCER_PREPARE_THRESHOLD:-5}
+      url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=${POSTGRES_SSL_MODE:-require}&prepareThreshold=${PGBOUNCER_PREPARE_THRESHOLD:-0}
       user: ${POSTGRES_USER}
       password: ${POSTGRES_PASSWORD}
       # HikariCP connection pool — sized for 3 API replicas × 10 connections each = 30 backend connections

--- a/chart/templates/marquez/configmap.yaml
+++ b/chart/templates/marquez/configmap.yaml
@@ -34,7 +34,10 @@ data:
     db:
       driverClass: org.postgresql.Driver
       # Add prepareThreshold=0 when PGBOUNCER_ENABLED=true (transaction mode requires no server-side prepared stmts)
-      url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=${POSTGRES_SSL_MODE:-prefer}&prepareThreshold=${PGBOUNCER_PREPARE_THRESHOLD:-0}
+      # currentSchema is passed explicitly so the app and Flyway target a known
+      # schema. On PostgreSQL 15+ the role must own this schema (it no longer has
+      # CREATE on public by default). Defaults to public.
+      url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?currentSchema=${POSTGRES_SCHEMA:-public}&sslmode=${POSTGRES_SSL_MODE:-prefer}&prepareThreshold=${PGBOUNCER_PREPARE_THRESHOLD:-0}
       user: ${POSTGRES_USER}
       password: ${POSTGRES_PASSWORD}
       maxSize: ${DB_POOL_MAX_SIZE:-20}

--- a/chart/templates/marquez/configmap.yaml
+++ b/chart/templates/marquez/configmap.yaml
@@ -33,9 +33,19 @@ data:
     # Enables database configuration overrides (see: https://www.dropwizard.io/en/stable/manual/configuration.html#database)
     db:
       driverClass: org.postgresql.Driver
-      url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+      # Add prepareThreshold=0 when PGBOUNCER_ENABLED=true (transaction mode requires no server-side prepared stmts)
+      url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=${POSTGRES_SSL_MODE:-prefer}&prepareThreshold=${PGBOUNCER_PREPARE_THRESHOLD:-5}
       user: ${POSTGRES_USER}
       password: ${POSTGRES_PASSWORD}
+      # HikariCP connection pool — sized for 3 API replicas × 10 connections each = 30 backend connections
+      # PgBouncer sits in front and fans out to PostgreSQL with its own pool
+      maxSize: ${DB_POOL_MAX_SIZE:-20}
+      minSize: ${DB_POOL_MIN_SIZE:-5}
+      maxWaitForConnection: 5s
+      validationQuery: "SELECT 1"
+      connectionTimeout: 5000
+      idleTimeout: 600000
+      maxLifetime: 1800000
     # Enables retention policy configuration for database (default: disabled)
     {{- if .Values.marquez.dbRetention }}
     dbRetention:
@@ -49,6 +59,13 @@ data:
     # Enables Apache AGE graph extension features (V3 Graph API)
     ageEnabled: ${MARQUEZ_AGE_ENABLED}
     logging:
-      level: ${LOG_LEVEL}
+      level: ${LOG_LEVEL:-WARN}
       appenders:
         - type: console
+          logFormat: "%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n"
+      loggers:
+        marquez: INFO
+        marquez.db: WARN
+        org.jdbi: WARN
+        org.postgresql: WARN
+        org.eclipse.jetty: WARN

--- a/chart/templates/marquez/deployment.yaml
+++ b/chart/templates/marquez/deployment.yaml
@@ -85,6 +85,8 @@ spec:
               value: {{ include "marquez.database.port" . | quote }}
             - name: POSTGRES_DB
               value: {{ include "marquez.database.name" . | quote }}
+            - name: POSTGRES_SCHEMA
+              value: {{ .Values.marquez.postgresSchema | default "public" | quote }}
             - name: POSTGRES_USER
               value: {{ include "marquez.database.user" . | quote }}
             - name: POSTGRES_PASSWORD

--- a/chart/templates/marquez/deployment.yaml
+++ b/chart/templates/marquez/deployment.yaml
@@ -105,7 +105,7 @@ spec:
             - name: DB_POOL_MIN_SIZE
               value: {{ .Values.marquez.dbPoolMinSize | default 5 | quote }}
             - name: PGBOUNCER_PREPARE_THRESHOLD
-              value: {{ .Values.marquez.pgbouncerPrepareThreshold | default "5" | quote }}
+              value: {{ .Values.marquez.pgbouncerPrepareThreshold | default "0" | quote }}
           {{- if .Values.marquez.resources }}
           resources: {{- toYaml .Values.marquez.resources | nindent 12 }}
           {{- end }}

--- a/chart/templates/marquez/deployment.yaml
+++ b/chart/templates/marquez/deployment.yaml
@@ -96,6 +96,16 @@ spec:
               value: {{ .Values.marquez.migrateOnStartup | quote }}
             - name: MARQUEZ_AGE_ENABLED
               value: {{ .Values.marquez.ageEnabled | quote }}
+            - name: JAVA_OPTS
+              value: {{ .Values.marquez.javaOpts | default "-Xms2g -Xmx5g -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+ExitOnOutOfMemoryError" | quote }}
+            - name: LOG_LEVEL
+              value: {{ .Values.marquez.logLevel | default "WARN" | quote }}
+            - name: DB_POOL_MAX_SIZE
+              value: {{ .Values.marquez.dbPoolMaxSize | default 20 | quote }}
+            - name: DB_POOL_MIN_SIZE
+              value: {{ .Values.marquez.dbPoolMinSize | default 5 | quote }}
+            - name: PGBOUNCER_PREPARE_THRESHOLD
+              value: {{ .Values.marquez.pgbouncerPrepareThreshold | default "5" | quote }}
           {{- if .Values.marquez.resources }}
           resources: {{- toYaml .Values.marquez.resources | nindent 12 }}
           {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -63,14 +63,36 @@ marquez:
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
   resources:
-    # Typically best to not specify these settings, unless you've got a specific
-    # reason to customize.
-    limits: {}
-    #    cpu: 200m
-    #    memory: 1Gi
-    requests: {}
-    #    memory: 256Mi
-    #    cpu: 250m
+    # Production sizing: 3 pods × 4 CPU / 8 Gi = 12 CPU / 24 Gi total per cluster
+    # JVM heap: -Xmx5g, non-heap + threads ~2 Gi → fits inside 8 Gi limit
+    limits:
+      cpu: "4"
+      memory: "8Gi"
+    requests:
+      cpu: "2"
+      memory: "5Gi"
+
+  # JVM and application tuning
+  javaOpts: >-
+    -Xms2g
+    -Xmx5g
+    -XX:+UseG1GC
+    -XX:MaxGCPauseMillis=200
+    -XX:InitiatingHeapOccupancyPercent=70
+    -XX:G1HeapRegionSize=16m
+    -XX:+ExitOnOutOfMemoryError
+    -Djava.security.egd=file:/dev/./urandom
+
+  # Log level — WARN for production. DEBUG at 1M events/day = 100M+ log lines/day
+  logLevel: "WARN"
+
+  # HikariCP pool size (per pod)
+  dbPoolMaxSize: 20
+  dbPoolMinSize: 5
+
+  # Set to 0 when routing through PgBouncer in transaction mode
+  pgbouncerPrepareThreshold: "0"
+
   podAnnotations: {}
   ## - name:
   ##   value:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,7 +12,7 @@ marquez:
   ##
   serviceAccount: "default"
   ## Number of desired replicas
-  ##
+  ## Production: set to 3 (3 pods × 20 HikariCP conns = 60 → PgBouncer default_pool_size 50)
   replicaCount: 1
   ## Marquez image version
   ## ref: https://hub.docker.com/r/marquezproject/marquez/tags/
@@ -49,9 +49,9 @@ marquez:
   ##
   migrateOnStartup: true
   ## Enables Apache AGE graph extension features (V3 Graph API).
-  ## Default: true for v3-beta deployments (AGE is assumed installed).
-  ## Set to false to run against a standard Postgres without AGE — V3 endpoints will 404.
-  ageEnabled: true
+  ## Set to true only when AGE is installed on the PostgreSQL server.
+  ## V3 endpoints return 404 when false. Currently deferred — single-DB Flex Server PG17 only.
+  ageEnabled: false
   ## Marquez will run using this hostname
   ##
   hostname: localhost

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -30,6 +30,8 @@ marquez:
   ##
   db:
     host: localhost
+    # Production: set port 6432 to use Azure Flex Server built-in PgBouncer (enabled via server parameter)
+    # Local dev: use 5432 for direct PostgreSQL access
     port: 5432
     name: marquez
     user: buendia

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -48,6 +48,10 @@ marquez:
   ## Indicates if Flyway database migration will execute upon deployment
   ##
   migrateOnStartup: true
+  ## PostgreSQL schema the application and Flyway target (passed as currentSchema
+  ## on the JDBC URL). On PostgreSQL 15+ the database role must own this schema —
+  ## the public schema no longer grants CREATE to non-owners. Defaults to public.
+  postgresSchema: "public"
   ## Enables Apache AGE graph extension features (V3 Graph API).
   ## Set to true only when AGE is installed on the PostgreSQL server.
   ## V3 endpoints return 404 when false. Currently deferred — single-DB Flex Server PG17 only.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       - MARQUEZ_PORT=${API_PORT}
       - MARQUEZ_ADMIN_PORT=${API_ADMIN_PORT}
       - POSTGRES_HOST=db
+      # Pass the schema explicitly on the JDBC connection (appended to the URL in
+      # marquez.dev.yml as ${POSTGRES_QUERY_PARAMS}). Defaults to the public schema.
+      - POSTGRES_QUERY_PARAMS=?currentSchema=${POSTGRES_SCHEMA:-public}
       - SEARCH_ENABLED=${SEARCH_ENABLED}
     ports:
       - "${API_PORT}:${API_PORT}"
@@ -33,6 +36,9 @@ services:
       - MARQUEZ_DB=marquez
       - MARQUEZ_USER=marquez
       - MARQUEZ_PASSWORD=marquez
+      # Schema owned by the marquez user; init-db.sh grants ownership so Flyway
+      # can create objects on PostgreSQL 15+. Must match currentSchema above.
+      - MARQUEZ_SCHEMA=${POSTGRES_SCHEMA:-public}
     volumes:
       - db-conf:/etc/postgresql
       - db-init:/docker-entrypoint-initdb.d

--- a/docker/init-db.sh
+++ b/docker/init-db.sh
@@ -7,6 +7,11 @@
 
 set -eu
 
+# Schema the Marquez application and Flyway migrations use. Defaults to "public"
+# so existing deployments are unaffected; override with MARQUEZ_SCHEMA to isolate
+# Marquez in a dedicated schema. Must match the currentSchema JDBC parameter.
+MARQUEZ_SCHEMA="${MARQUEZ_SCHEMA:-public}"
+
 psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" > /dev/null <<-EOSQL
   CREATE USER ${MARQUEZ_USER};
   ALTER USER ${MARQUEZ_USER} WITH PASSWORD '${MARQUEZ_PASSWORD}';
@@ -15,6 +20,16 @@ psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" > /dev/null <<-EOSQL
 EOSQL
 
 psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname="${MARQUEZ_DB}" > /dev/null <<-EOSQL
+  -- PostgreSQL 15+ no longer grants CREATE on the public schema to non-owners.
+  -- The Marquez app user must own (and create objects in) its schema, otherwise
+  -- Flyway cannot create the schema-history table and migrations fail with
+  -- "permission denied for schema public". Required now that the DB image is
+  -- PostgreSQL 17. CREATE ... AUTHORIZATION is a no-op when the schema already
+  -- exists (e.g. public), so the explicit ALTER OWNER handles that case.
+  CREATE SCHEMA IF NOT EXISTS ${MARQUEZ_SCHEMA} AUTHORIZATION ${MARQUEZ_USER};
+  ALTER SCHEMA ${MARQUEZ_SCHEMA} OWNER TO ${MARQUEZ_USER};
+  GRANT ALL ON SCHEMA ${MARQUEZ_SCHEMA} TO ${MARQUEZ_USER};
+
   CREATE EXTENSION IF NOT EXISTS age;
   -- Grant the marquez app user access to ag_catalog so Flyway migrations and
   -- the application can query AGE catalog tables and call AGE functions.

--- a/docker/postgres-age/Dockerfile
+++ b/docker/postgres-age/Dockerfile
@@ -1,27 +1,28 @@
-# Stage 1: Build the Apache AGE extension from source
-FROM postgres:14 AS builder
+# Stage 1: Build the Apache AGE extension from source against PostgreSQL 17
+FROM postgres:17 AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \
     git \
-    postgresql-server-dev-14 \
+    postgresql-server-dev-17 \
     flex \
     bison \
     && rm -rf /var/lib/apt/lists/*
 
-# Clone and build Apache AGE for PG 14
-RUN git clone -b PG14 --depth 1 https://github.com/apache/age.git /tmp/age \
+# Clone and build Apache AGE for PG 17
+# Apache AGE community supports PG 17 via the PG17 branch
+RUN git clone -b PG17 --depth 1 https://github.com/apache/age.git /tmp/age \
     && cd /tmp/age \
     && make \
     && make install
 
 # Stage 2: Create the minimal production-ready database image
-FROM postgres:14
+FROM postgres:17
 
 # Copy the compiled Apache AGE extension binaries and libraries from the builder stage
-COPY --from=builder /usr/lib/postgresql/14/lib/age.so /usr/lib/postgresql/14/lib/
-COPY --from=builder /usr/share/postgresql/14/extension/age* /usr/share/postgresql/14/extension/
+COPY --from=builder /usr/lib/postgresql/17/lib/age.so /usr/lib/postgresql/17/lib/
+COPY --from=builder /usr/share/postgresql/17/extension/age* /usr/share/postgresql/17/extension/
 
 # Bake shared_preload_libraries into the image so AGE is preloaded regardless of
 # whether a custom postgresql.conf is mounted at runtime. Without this, CREATE EXTENSION age

--- a/docs/azure-production-config.md
+++ b/docs/azure-production-config.md
@@ -1,0 +1,506 @@
+# Marquez Production Config: Azure PostgreSQL Flex Server + AKS
+# Long-Term Lineage Strategy: V1/V2 vs V3 (AGE) vs Pre-built Graph
+
+---
+
+## 1. Why You're Struggling While Instagram/OpenAI Don't
+
+The issue is **not PostgreSQL**. It is the operating point.
+
+Marquez was designed for ~10,000 lineage events/day with 1–5 events per run.
+You are operating at:
+
+```
+1,000,000 events/day × 200 Spark events/run = 5,000 job runs/day
+                                              × 200 DB writes each
+                                              = 30,000,000 upserts/day (before our fix)
+```
+
+Instagram and OpenAI run at billion-row scale on PostgreSQL because they obey two rules:
+
+| Rule | Instagram/OpenAI | Current Marquez |
+|---|---|---|
+| Write pattern | Append-only INSERT | UPDATE same row 200 times per run |
+| Read pattern | Pre-materialized adjacency, simple SELECT | Live recursive BFS CTE at query time |
+| Graph traversal | Precomputed at write time | Computed on every API request |
+| JSON aggregation | Avoided in hot queries | `JSON_AGG(DISTINCT jsonb_build_object(...))` in recursive CTEs |
+| Log level | WARN in prod | **DEBUG for everything** (current config.yml) |
+| Connection pooling | PgBouncer, 200+ connections | Default HikariCP 8-10 connections |
+
+The `logging.level: DEBUG` in your `config.yml` alone at 1M events/day generates
+100M+ log lines/day and costs 10–20% extra CPU on the API pod.
+
+---
+
+## 2. Long-Term Strategy: Which API Version Wins?
+
+### The Honest Answer
+
+**V2 wins for the next 12–18 months. V3 (AGE with pre-built graph) wins long-term.**
+
+Here is the breakdown:
+
+```
+                    Now        6 months      18 months
+V1 (normalized)     ████       ██            █         (keep for writes, retire from reads)
+V2 (denorm tables)  ████       ████████      ████████  (primary read path)
+V3 AGE live CTE     ██         ██            ░░        (same CTE problem, just in Cypher)
+V3 AGE pre-built    ░░         ████          ████████  (target end state)
+```
+
+### Why V3 Live Cypher Doesn't Solve the Problem
+
+The current V3 implementation:
+```
+Event arrives → write to relational + write to AGE graph → read via Cypher MATCH traversal
+```
+
+Cypher `MATCH (a)-[*1..10]->(b)` is STILL a live BFS traversal of the graph —
+it just uses graph indexes instead of recursive CTEs. At depth=10 on a graph
+with 5,000 new nodes per day × 730 days = 3.65M nodes, Cypher traversal has
+the same fan-out explosion problem as the SQL recursive CTE.
+
+### The Fix: Pre-Built Lineage Graph (Pre-Materialized Edges)
+
+The correct V3 design computes all reachable edges **at write time**, not at read time.
+
+```
+Event arrives → extract (from_node, to_node) pairs → INSERT into lineage_edges
+Read request → SELECT from lineage_edges WHERE from_node_id IN (...) LIMIT N
+              → No BFS, no CTE, no graph traversal — just N indexed point lookups
+```
+
+This is how OpenMetadata works. They store explicit upstream/downstream entity
+relationships as rows, not as a graph to be traversed. For depth=5 you do
+5 sequential indexed queries, each milliseconds.
+
+### OpenMetadata vs Marquez Lineage Design
+
+| Aspect | OpenMetadata | Marquez V1/V2 | Marquez V3 Target |
+|---|---|---|---|
+| Storage | Edge table (entity_relationship) | Recursive normalized tables | AGE graph pre-built |
+| Read depth=1 | 1 indexed SELECT | 1 recursive CTE step | 1 AGE hop |
+| Read depth=5 | 5 indexed SELECTs in Java | 1 CTE (5 recursions, expensive) | 5 AGE hops (fast with indexes) |
+| Read depth=10 | 10 indexed SELECTs | 1 CTE (10 recursions, can OOM) | NOT recommended |
+| Write pattern | 1 INSERT per edge on COMPLETE | Upsert on every event (200×) | 1 INSERT per edge on COMPLETE |
+| BFS location | Application code (Java) | PostgreSQL planner | AGE engine |
+| Cache-friendly | Yes (each level cacheable) | No (full graph per request) | Partially |
+| Scale ceiling | ~100M edges | ~50M rows before pain | ~1B nodes/edges |
+
+**For your workload, the OpenMetadata pattern is pragmatic and proven.**
+The Marquez V3 end-state (AGE with pre-built edges, not live traversal) achieves the same thing but with richer graph query capability (shortest path, impact analysis, etc.).
+
+### Recommended Phases
+
+```
+Phase 1 (done)   — Fix recursive CTE OR→UNION, depth caps, tautology bug, write churn
+Phase 2 (now)    — Add lineage_edges materialized table (see below)
+Phase 3 (6mo)    — V2 reads use lineage_edges instead of recursive CTE
+Phase 4 (18mo)   — V3 AGE graph populated from lineage_edges (pre-built, not live-traversed)
+```
+
+### The lineage_edges Table (Phase 2)
+
+```sql
+-- Pre-computed adjacency table populated at event COMPLETE time only
+-- No recursive CTE needed for reads — just N simple indexed lookups
+CREATE TABLE lineage_edges (
+    from_node_id   UUID     NOT NULL,
+    from_type      TEXT     NOT NULL,  -- 'dataset_version', 'run', 'job'
+    to_node_id     UUID     NOT NULL,
+    to_type        TEXT     NOT NULL,
+    edge_type      TEXT     NOT NULL,  -- 'PRODUCES', 'CONSUMES'
+    run_uuid       UUID     NOT NULL,
+    run_date       DATE     NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (from_node_id, to_node_id, edge_type)
+) PARTITION BY RANGE (run_date);
+
+-- Two directional indexes replace all recursive CTE traversal
+CREATE INDEX idx_lineage_edges_upstream
+    ON lineage_edges (to_node_id, from_type, run_date);
+CREATE INDEX idx_lineage_edges_downstream
+    ON lineage_edges (from_node_id, to_type, run_date);
+```
+
+At **depth=5** the read path becomes:
+```java
+// Java BFS — 5 indexed SELECT calls, each sub-millisecond
+Set<UUID> frontier = Set.of(startNodeId);
+for (int d = 0; d < depth; d++) {
+    Set<UUID> next = dao.getDirectNeighbors(frontier);  // single indexed SELECT
+    result.addAll(next);
+    frontier = next;
+}
+```
+
+This matches OpenMetadata's approach exactly. No recursive CTE, no OOM risk,
+no depth-related performance cliff, cacheable per level.
+
+---
+
+## 3. Azure PostgreSQL Flexible Server Configuration
+
+### SKU Selection
+
+**Do NOT use Azure PostgreSQL Flexible Server for V3 (AGE).**
+Azure does not allow custom extensions like AGE. Use Flex Server for V1/V2 only.
+
+| Workload Stage | Recommended SKU | vCores | RAM | IOPS |
+|---|---|---|---|---|
+| Now (1M events/day, V1/V2) | Standard_E8ds_v5 | 8 | 64 GB | up to 25,600 |
+| 3M events/day | Standard_E16ds_v5 | 16 | 128 GB | up to 51,200 |
+| With read replica for lineage reads | Primary E8ds_v5 + Replica E4ds_v5 | — | — | — |
+
+**Storage:** Premium SSD v2, 500 GB minimum, IOPS provisioned at 5,000 initially.
+Enable auto-grow. At 1M events/day the lineage_events table grows ~150 GB/year.
+
+### PostgreSQL Server Parameters (set in Azure Portal → Server Parameters)
+
+```
+# Memory
+shared_buffers                    = 16384    (MB — 25% of 64 GB RAM)
+effective_cache_size              = 49152    (MB — 75% of 64 GB RAM)
+work_mem                          = 128      (MB — PER SORT per connection; recursive CTEs use multiple)
+maintenance_work_mem              = 2048     (MB — for VACUUM and index builds)
+temp_buffers                      = 32       (MB)
+
+# Write performance
+wal_buffers                       = 64       (MB)
+checkpoint_completion_target      = 0.9
+min_wal_size                      = 2048     (MB)
+max_wal_size                      = 8192     (MB)
+synchronous_commit                = off      (safe for lineage events — eventual consistency acceptable)
+                                             # IMPORTANT: set to 'on' for run state transitions
+
+# I/O (Premium SSD v2)
+random_page_cost                  = 1.1      (SSD — lower than spinning disk default of 4)
+effective_io_concurrency          = 200      (SSD)
+seq_page_cost                     = 1.0
+
+# Parallelism
+max_worker_processes              = 8        (= vCores)
+max_parallel_workers              = 8
+max_parallel_workers_per_gather   = 4
+parallel_tuple_cost               = 0.1
+
+# Connections
+max_connections                   = 200      (PgBouncer sits in front; real backend connections ~80)
+
+# Autovacuum — critical for high-write tables
+autovacuum_max_workers            = 6
+autovacuum_vacuum_scale_factor    = 0.02     (vacuum when 2% of table modified — default is 20%)
+autovacuum_analyze_scale_factor   = 0.01
+autovacuum_vacuum_cost_delay      = 2        (ms — aggressive vacuum pace)
+autovacuum_vacuum_cost_limit      = 800      (default 200 — allows faster VACUUM)
+autovacuum_naptime                = 30       (seconds between autovacuum checks)
+
+# Query behavior
+lock_timeout                      = 5000     (ms)
+statement_timeout                 = 30000    (ms — kill queries >30s; prevents runaway lineage CTEs)
+idle_in_transaction_session_timeout = 10000 (ms)
+
+# Logging — INFO only in production
+log_min_duration_statement        = 5000     (ms — only log queries >5s)
+log_connections                   = off
+log_disconnections                = off
+log_duration                      = off
+
+# Extensions
+shared_preload_libraries          = pg_stat_statements
+pg_stat_statements.track          = all
+track_activity_query_size         = 4096
+```
+
+### Connection Pooling: PgBouncer on AKS
+
+Run PgBouncer as a sidecar or dedicated Deployment. Use **transaction pooling**.
+
+```ini
+# pgbouncer.ini
+[databases]
+marquez = host=<azure-flex-hostname> port=5432 dbname=marquez
+
+[pgbouncer]
+pool_mode = transaction
+max_client_conn = 500          ; max Marquez API connections across all pods
+default_pool_size = 50         ; PostgreSQL backend connections per database
+min_pool_size = 10
+reserve_pool_size = 10
+reserve_pool_timeout = 3       ; seconds before using reserve pool
+server_idle_timeout = 600
+server_lifetime = 3600
+server_connect_timeout = 10
+client_idle_timeout = 60
+query_timeout = 30             ; kill client query after 30s — matches PG statement_timeout
+stats_period = 60
+
+# Authentication
+auth_type = scram-sha-256
+auth_file = /etc/pgbouncer/userlist.txt
+```
+
+---
+
+## 4. AKS Pod Configuration
+
+### Marquez API Deployment (values.yaml — production override)
+
+```yaml
+# chart/values-production.yaml
+marquez:
+  replicaCount: 3                    # Minimum for production HA; add HPA for burst
+
+  image:
+    repository: swar00pduth/marquez
+    tag: 0.52.43
+
+  resources:
+    requests:
+      cpu: "2"
+      memory: "5Gi"
+    limits:
+      cpu: "4"
+      memory: "8Gi"                  # JVM heap capped at 5Gi, overhead ~2.5Gi → fits in 8Gi limit
+
+  # Pass JVM flags via env (add to deployment.yaml)
+  # JAVA_OPTS set in extraEnv below
+  extraEnv:
+    - name: JAVA_OPTS
+      value: >-
+        -Xms2g
+        -Xmx5g
+        -XX:+UseG1GC
+        -XX:MaxGCPauseMillis=200
+        -XX:InitiatingHeapOccupancyPercent=70
+        -XX:G1HeapRegionSize=16m
+        -XX:+ExitOnOutOfMemoryError
+        -Djava.security.egd=file:/dev/./urandom
+        -Dfile.encoding=UTF-8
+    - name: LOG_LEVEL
+      value: "WARN"                  # CRITICAL: DEBUG at 1M events/day = 100M log lines/day
+
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "5001"
+    prometheus.io/path: "/metrics"
+
+  # Anti-affinity: spread API pods across AKS nodes
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: marquez
+```
+
+### Marquez Config for Production (config.yml via ConfigMap)
+
+```yaml
+server:
+  applicationConnectors:
+    - type: http
+      port: ${MARQUEZ_PORT:-5000}
+      httpCompliance: RFC7230_LEGACY
+      # Jetty thread pool — size to handle burst from 5,000 Spark jobs
+      acceptorThreads: 2
+      selectorThreads: 8
+  adminConnectors:
+    - type: http
+      port: ${MARQUEZ_ADMIN_PORT:-5001}
+  gzip:
+    enabled: true
+    minimumEntitySize: 256 bytes     # Compress all lineage responses >256B
+    bufferSize: 8KiB
+
+db:
+  driverClass: org.postgresql.Driver
+  url: jdbc:postgresql://${PGBOUNCER_HOST}:5432/marquez?sslmode=require&prepareThreshold=0
+  #                      ^^^^^^^^^^^^^^^^ — point at PgBouncer, NOT Flex Server directly
+  #                                       prepareThreshold=0 required for PgBouncer transaction mode
+  user: ${POSTGRES_USER}
+  password: ${POSTGRES_PASSWORD}
+
+  # HikariCP pool — talk to PgBouncer, so pool can be larger
+  maxSize: 30                        # PgBouncer handles the real PG connection limit
+  minSize: 10
+  maxWaitForConnection: 5s
+  validationQuery: "SELECT 1"
+  connectionTimeout: 5000
+  idleTimeout: 600000
+  maxLifetime: 1800000
+  # Disable server-side prepared statements — required for PgBouncer transaction mode
+  initializationQuery: "SET search_path=public"
+
+migrateOnStartup: true
+ageEnabled: ${MARQUEZ_AGE_ENABLED:-false}  # false for Flex Server (no AGE support)
+
+logging:
+  level: WARN                        # NOT DEBUG — this is the most impactful single change
+  appenders:
+    - type: console
+      logFormat: "%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n"
+  loggers:
+    marquez: INFO                    # Marquez service-level events (starts, errors)
+    marquez.db: WARN                 # SQL only on warnings — DEBUG is 100M lines/day at 1M events
+    org.jdbi: WARN
+    org.postgresql: WARN
+    org.eclipse.jetty: WARN
+```
+
+### HPA (Horizontal Pod Autoscaler)
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: marquez-api-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: marquez
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+```
+
+### AGE Pod (V3 only — separate StatefulSet, NOT on Azure Flex Server)
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres-age
+spec:
+  serviceName: postgres-age
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres-age
+  template:
+    spec:
+      containers:
+        - name: postgres-age
+          image: swar00pduth/postgres-age:14-latest
+          resources:
+            requests:
+              cpu: "2"
+              memory: "16Gi"         # AGE graph in-memory traversal needs RAM
+            limits:
+              cpu: "4"
+              memory: "32Gi"
+          env:
+            - name: POSTGRES_DB
+              value: marquez_graph
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+            - name: POSTGRES_SHARED_BUFFERS
+              value: "8GB"
+            - name: POSTGRES_WORK_MEM
+              value: "256MB"         # AGE graph queries need more work_mem than relational
+          args:
+            - postgres
+            - -c
+            - shared_buffers=8GB
+            - -c
+            - work_mem=256MB
+            - -c
+            - effective_cache_size=24GB
+            - -c
+            - max_connections=50    # Only Marquez V3 pods talk to this
+            - -c
+            - shared_preload_libraries=age,pg_stat_statements
+            - -c
+            - statement_timeout=15000
+          volumeMounts:
+            - name: postgres-age-data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-age-data
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: managed-premium  # Azure Premium SSD
+        resources:
+          requests:
+            storage: 200Gi           # Graph only — much smaller than relational store
+```
+
+---
+
+## 5. Node Pool Sizing for AKS
+
+```
+┌──────────────────────────────────────────────────────┐
+│  Node Pool: marquez-api                              │
+│  VM SKU: Standard_D4ds_v5 (4 vCPU, 16 GB RAM)       │
+│  Count: 3 (min) → 8 (max with cluster autoscaler)   │
+│  Each node runs: 1 Marquez API pod + PgBouncer       │
+│  Taints: none (shared pool OK)                       │
+└──────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────┐
+│  Node Pool: postgres-age                             │
+│  VM SKU: Standard_E8s_v5 (8 vCPU, 64 GB RAM)        │
+│  Count: 1 (StatefulSet — no horizontal scale for PG) │
+│  Taints: dedicated=postgres-age:NoSchedule           │
+│  Tolerations: on AGE StatefulSet only                │
+└──────────────────────────────────────────────────────┘
+```
+
+---
+
+## 6. Data Volume Projections at 1M Events/Day (2 Years)
+
+| Table | Row/day | Row size | 2-yr size | Action |
+|---|---|---|---|---|
+| lineage_events | 1,000,000 | ~200B | **146 GB** | Already indexed by run_date |
+| run_facets | **10,000,000** | ~150B | **1.1 TB** | **Partition urgently — V107** |
+| run_lineage_denormalized | 150,000 | ~500B | 54 GB | Manageable with partitions |
+| runs | 5,000 | ~300B | 2.1 GB | Small |
+| dataset_versions | 10,000 | ~200B | 5.5 GB | Small |
+| lineage_edges (new) | 30,000 | ~100B | 18 GB | Replace CTE reads |
+
+**`run_facets` at 1.1 TB is the immediate 2-year time bomb.**
+With 10 facets per event × 1M events/day = 10M rows/day × 730 days = **7.3 billion rows**.
+This table must be range-partitioned by `lineage_event_time` before month 4.
+
+```sql
+-- Run BEFORE run_facets hits 500M rows
+-- Schedule as a one-time maintenance window (requires brief downtime or logical replication)
+CREATE TABLE run_facets_new (LIKE run_facets INCLUDING ALL)
+    PARTITION BY RANGE (lineage_event_time);
+-- Monthly partitions, 12-month retention (facets are hot for 12 months, cold after)
+```
+
+---
+
+## 7. Most Impactful Changes — Ranked by ROI
+
+| Rank | Change | Effort | Impact |
+|---|---|---|---|
+| 1 | `logging.level: WARN` in production config | 5 min | 10–20% CPU freed immediately |
+| 2 | Gate denorm writes on START/COMPLETE/FAIL only (done) | done | 100× write IOPS reduction |
+| 3 | PgBouncer transaction pooling | 1 hour | Fixes connection exhaustion under Spark burst |
+| 4 | `statement_timeout=30s` on Azure Flex Server | 5 min | Kills runaway CTEs, frees connections |
+| 5 | Fix tautology bug `dvf.run_uuid = dvf.run_uuid` (done) | done | 50×+ response size reduction |
+| 6 | Partition `run_facets` by `lineage_event_time` | 1 day | Prevents 1.1 TB unpartitioned table |
+| 7 | Build `lineage_edges` table, move reads off recursive CTEs | 1 week | Eliminates BFS CPU cost entirely |
+| 8 | Move to `Standard_E8ds_v5` with `synchronous_commit=off` | 2 hours | 3× write throughput on Flex Server |
+| 9 | Add read replica for lineage GET queries | 2 hours | Write path isolated from read path |
+| 10 | V3 AGE pre-built graph (NOT live Cypher traversal) | 2 months | Long-term stable graph API |

--- a/docs/azure-production-config.md
+++ b/docs/azure-production-config.md
@@ -1,6 +1,39 @@
 # Marquez Production Config: Azure PostgreSQL Flex Server + AKS
 # Long-Term Lineage Strategy: V1/V2 vs V3 (AGE) vs Pre-built Graph
 
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  AKS Cluster                                                     │
+│                                                                  │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐           │
+│  │  Marquez API │  │  Marquez API │  │  Marquez API │  ×3 pods  │
+│  │  Pod         │  │  Pod         │  │  Pod         │           │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘           │
+│         └─────────────────┴─────────────────┘                   │
+│                           │                                      │
+└───────────────────────────┼──────────────────────────────────────┘
+                            │ JDBC (port 6432 — built-in PgBouncer)
+                            ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  Azure PostgreSQL Flexible Server — PG 17 + AGE extension        │
+│                                                                  │
+│  Built-in PgBouncer (transaction mode, port 6432)                │
+│  ↓ fans out to ↓                                                 │
+│  PostgreSQL 17 backend (port 5432)                               │
+│                                                                  │
+│  Extensions: age, pg_stat_statements                             │
+│  V1 tables:  runs, jobs, datasets, lineage_events, run_facets    │
+│  V2 tables:  run_lineage_denormalized, dataset_denormalized, ... │
+│  V3 graph:   ag_catalog (Apache AGE graph for Cypher queries)    │
+│  Pre-mat:    lineage_edges (BFS adjacency — replaces CTE reads)  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Single database instance serves all three API versions. No separate pod for AGE.
+PgBouncer is Azure-managed via server parameter — no sidecar or extra Deployment needed.
+
 ---
 
 ## 1. Why You're Struggling While Instagram/OpenAI Don't
@@ -38,8 +71,6 @@ The `logging.level: DEBUG` in your `config.yml` alone at 1M events/day generates
 
 **V2 wins for the next 12–18 months. V3 (AGE with pre-built graph) wins long-term.**
 
-Here is the breakdown:
-
 ```
                     Now        6 months      18 months
 V1 (normalized)     ████       ██            █         (keep for writes, retire from reads)
@@ -50,11 +81,6 @@ V3 AGE pre-built    ░░         ████          ███████�
 
 ### Why V3 Live Cypher Doesn't Solve the Problem
 
-The current V3 implementation:
-```
-Event arrives → write to relational + write to AGE graph → read via Cypher MATCH traversal
-```
-
 Cypher `MATCH (a)-[*1..10]->(b)` is STILL a live BFS traversal of the graph —
 it just uses graph indexes instead of recursive CTEs. At depth=10 on a graph
 with 5,000 new nodes per day × 730 days = 3.65M nodes, Cypher traversal has
@@ -62,80 +88,23 @@ the same fan-out explosion problem as the SQL recursive CTE.
 
 ### The Fix: Pre-Built Lineage Graph (Pre-Materialized Edges)
 
-The correct V3 design computes all reachable edges **at write time**, not at read time.
-
 ```
 Event arrives → extract (from_node, to_node) pairs → INSERT into lineage_edges
 Read request → SELECT from lineage_edges WHERE from_node_id IN (...) LIMIT N
               → No BFS, no CTE, no graph traversal — just N indexed point lookups
 ```
 
-This is how OpenMetadata works. They store explicit upstream/downstream entity
-relationships as rows, not as a graph to be traversed. For depth=5 you do
-5 sequential indexed queries, each milliseconds.
-
-### OpenMetadata vs Marquez Lineage Design
-
-| Aspect | OpenMetadata | Marquez V1/V2 | Marquez V3 Target |
-|---|---|---|---|
-| Storage | Edge table (entity_relationship) | Recursive normalized tables | AGE graph pre-built |
-| Read depth=1 | 1 indexed SELECT | 1 recursive CTE step | 1 AGE hop |
-| Read depth=5 | 5 indexed SELECTs in Java | 1 CTE (5 recursions, expensive) | 5 AGE hops (fast with indexes) |
-| Read depth=10 | 10 indexed SELECTs | 1 CTE (10 recursions, can OOM) | NOT recommended |
-| Write pattern | 1 INSERT per edge on COMPLETE | Upsert on every event (200×) | 1 INSERT per edge on COMPLETE |
-| BFS location | Application code (Java) | PostgreSQL planner | AGE engine |
-| Cache-friendly | Yes (each level cacheable) | No (full graph per request) | Partially |
-| Scale ceiling | ~100M edges | ~50M rows before pain | ~1B nodes/edges |
-
-**For your workload, the OpenMetadata pattern is pragmatic and proven.**
-The Marquez V3 end-state (AGE with pre-built edges, not live traversal) achieves the same thing but with richer graph query capability (shortest path, impact analysis, etc.).
+This is how OpenMetadata works. At depth=5 you do 5 sequential indexed queries,
+each milliseconds. No OOM risk, no planner problem, cacheable per level.
 
 ### Recommended Phases
 
 ```
 Phase 1 (done)   — Fix recursive CTE OR→UNION, depth caps, tautology bug, write churn
-Phase 2 (now)    — Add lineage_edges materialized table (see below)
+Phase 2 (done)   — Add lineage_edges materialized table (V107 migration)
 Phase 3 (6mo)    — V2 reads use lineage_edges instead of recursive CTE
 Phase 4 (18mo)   — V3 AGE graph populated from lineage_edges (pre-built, not live-traversed)
 ```
-
-### The lineage_edges Table (Phase 2)
-
-```sql
--- Pre-computed adjacency table populated at event COMPLETE time only
--- No recursive CTE needed for reads — just N simple indexed lookups
-CREATE TABLE lineage_edges (
-    from_node_id   UUID     NOT NULL,
-    from_type      TEXT     NOT NULL,  -- 'dataset_version', 'run', 'job'
-    to_node_id     UUID     NOT NULL,
-    to_type        TEXT     NOT NULL,
-    edge_type      TEXT     NOT NULL,  -- 'PRODUCES', 'CONSUMES'
-    run_uuid       UUID     NOT NULL,
-    run_date       DATE     NOT NULL,
-    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    PRIMARY KEY (from_node_id, to_node_id, edge_type)
-) PARTITION BY RANGE (run_date);
-
--- Two directional indexes replace all recursive CTE traversal
-CREATE INDEX idx_lineage_edges_upstream
-    ON lineage_edges (to_node_id, from_type, run_date);
-CREATE INDEX idx_lineage_edges_downstream
-    ON lineage_edges (from_node_id, to_type, run_date);
-```
-
-At **depth=5** the read path becomes:
-```java
-// Java BFS — 5 indexed SELECT calls, each sub-millisecond
-Set<UUID> frontier = Set.of(startNodeId);
-for (int d = 0; d < depth; d++) {
-    Set<UUID> next = dao.getDirectNeighbors(frontier);  // single indexed SELECT
-    result.addAll(next);
-    frontier = next;
-}
-```
-
-This matches OpenMetadata's approach exactly. No recursive CTE, no OOM risk,
-no depth-related performance cliff, cacheable per level.
 
 ---
 
@@ -143,17 +112,40 @@ no depth-related performance cliff, cacheable per level.
 
 ### SKU Selection
 
-**Do NOT use Azure PostgreSQL Flexible Server for V3 (AGE).**
-Azure does not allow custom extensions like AGE. Use Flex Server for V1/V2 only.
-
 | Workload Stage | Recommended SKU | vCores | RAM | IOPS |
 |---|---|---|---|---|
-| Now (1M events/day, V1/V2) | Standard_E8ds_v5 | 8 | 64 GB | up to 25,600 |
+| Now (1M events/day) | Standard_E8ds_v5 | 8 | 64 GB | up to 25,600 |
 | 3M events/day | Standard_E16ds_v5 | 16 | 128 GB | up to 51,200 |
 | With read replica for lineage reads | Primary E8ds_v5 + Replica E4ds_v5 | — | — | — |
 
 **Storage:** Premium SSD v2, 500 GB minimum, IOPS provisioned at 5,000 initially.
 Enable auto-grow. At 1M events/day the lineage_events table grows ~150 GB/year.
+
+### Built-in PgBouncer (Server Parameter — No Sidecar Needed)
+
+Enable PgBouncer as a server parameter in the Azure Portal:
+
+```
+Server parameters to set in Azure Portal:
+  pgbouncer.enabled              = true
+  pgbouncer.pool_mode            = transaction      ← CRITICAL for correctness
+  pgbouncer.max_client_conn      = 500
+  pgbouncer.default_pool_size    = 50
+  pgbouncer.min_pool_size        = 10
+  pgbouncer.server_idle_timeout  = 600
+  pgbouncer.query_timeout        = 30
+```
+
+When enabled, PgBouncer listens on **port 6432** on the same hostname as your
+Flex Server. Your JDBC URL must point to port 6432, NOT 5432:
+
+```
+jdbc:postgresql://<flex-server-hostname>:6432/marquez?sslmode=require&prepareThreshold=0
+```
+
+`prepareThreshold=0` disables server-side prepared statements, which is required
+for PgBouncer transaction mode. This is already set in the Helm chart via
+`PGBOUNCER_PREPARE_THRESHOLD=0`.
 
 ### PostgreSQL Server Parameters (set in Azure Portal → Server Parameters)
 
@@ -184,8 +176,8 @@ max_parallel_workers              = 8
 max_parallel_workers_per_gather   = 4
 parallel_tuple_cost               = 0.1
 
-# Connections
-max_connections                   = 200      (PgBouncer sits in front; real backend connections ~80)
+# Connections (PgBouncer sits in front; ~50 real PostgreSQL connections from PgBouncer)
+max_connections                   = 100
 
 # Autovacuum — critical for high-write tables
 autovacuum_max_workers            = 6
@@ -206,38 +198,10 @@ log_connections                   = off
 log_disconnections                = off
 log_duration                      = off
 
-# Extensions
-shared_preload_libraries          = pg_stat_statements
+# Extensions (set shared_preload_libraries in Azure Portal)
+shared_preload_libraries          = pg_stat_statements,age
 pg_stat_statements.track          = all
 track_activity_query_size         = 4096
-```
-
-### Connection Pooling: PgBouncer on AKS
-
-Run PgBouncer as a sidecar or dedicated Deployment. Use **transaction pooling**.
-
-```ini
-# pgbouncer.ini
-[databases]
-marquez = host=<azure-flex-hostname> port=5432 dbname=marquez
-
-[pgbouncer]
-pool_mode = transaction
-max_client_conn = 500          ; max Marquez API connections across all pods
-default_pool_size = 50         ; PostgreSQL backend connections per database
-min_pool_size = 10
-reserve_pool_size = 10
-reserve_pool_timeout = 3       ; seconds before using reserve pool
-server_idle_timeout = 600
-server_lifetime = 3600
-server_connect_timeout = 10
-client_idle_timeout = 60
-query_timeout = 30             ; kill client query after 30s — matches PG statement_timeout
-stats_period = 60
-
-# Authentication
-auth_type = scram-sha-256
-auth_file = /etc/pgbouncer/userlist.txt
 ```
 
 ---
@@ -249,7 +213,7 @@ auth_file = /etc/pgbouncer/userlist.txt
 ```yaml
 # chart/values-production.yaml
 marquez:
-  replicaCount: 3                    # Minimum for production HA; add HPA for burst
+  replicaCount: 3
 
   image:
     repository: swar00pduth/marquez
@@ -263,37 +227,44 @@ marquez:
       cpu: "4"
       memory: "8Gi"                  # JVM heap capped at 5Gi, overhead ~2.5Gi → fits in 8Gi limit
 
-  # Pass JVM flags via env (add to deployment.yaml)
-  # JAVA_OPTS set in extraEnv below
-  extraEnv:
-    - name: JAVA_OPTS
-      value: >-
-        -Xms2g
-        -Xmx5g
-        -XX:+UseG1GC
-        -XX:MaxGCPauseMillis=200
-        -XX:InitiatingHeapOccupancyPercent=70
-        -XX:G1HeapRegionSize=16m
-        -XX:+ExitOnOutOfMemoryError
-        -Djava.security.egd=file:/dev/./urandom
-        -Dfile.encoding=UTF-8
-    - name: LOG_LEVEL
-      value: "WARN"                  # CRITICAL: DEBUG at 1M events/day = 100M log lines/day
+  db:
+    host: <flex-server-hostname>
+    port: 6432                        # ← PgBouncer port (NOT 5432)
+    name: marquez
+    user: buendia
+    # password: set via existingSecretName
+
+  javaOpts: >-
+    -Xms2g
+    -Xmx5g
+    -XX:+UseG1GC
+    -XX:MaxGCPauseMillis=200
+    -XX:InitiatingHeapOccupancyPercent=70
+    -XX:G1HeapRegionSize=16m
+    -XX:+ExitOnOutOfMemoryError
+    -Djava.security.egd=file:/dev/./urandom
+
+  logLevel: "WARN"
+  dbPoolMaxSize: 20
+  dbPoolMinSize: 5
+  pgbouncerPrepareThreshold: "0"     # Required for PgBouncer transaction mode
+
+  ageEnabled: true                   # AGE is enabled on Azure Flex Server PG 17
 
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "5001"
     prometheus.io/path: "/metrics"
 
-  # Anti-affinity: spread API pods across AKS nodes
-  podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          topologyKey: kubernetes.io/hostname
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/component: marquez
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: marquez
 ```
 
 ### Marquez Config for Production (config.yml via ConfigMap)
@@ -304,7 +275,6 @@ server:
     - type: http
       port: ${MARQUEZ_PORT:-5000}
       httpCompliance: RFC7230_LEGACY
-      # Jetty thread pool — size to handle burst from 5,000 Spark jobs
       acceptorThreads: 2
       selectorThreads: 8
   adminConnectors:
@@ -312,39 +282,35 @@ server:
       port: ${MARQUEZ_ADMIN_PORT:-5001}
   gzip:
     enabled: true
-    minimumEntitySize: 256 bytes     # Compress all lineage responses >256B
+    minimumEntitySize: 256 bytes
     bufferSize: 8KiB
 
 db:
   driverClass: org.postgresql.Driver
-  url: jdbc:postgresql://${PGBOUNCER_HOST}:5432/marquez?sslmode=require&prepareThreshold=0
-  #                      ^^^^^^^^^^^^^^^^ — point at PgBouncer, NOT Flex Server directly
-  #                                       prepareThreshold=0 required for PgBouncer transaction mode
+  # Port 6432 = Azure Flex Server built-in PgBouncer (transaction mode)
+  # prepareThreshold=0 disables server-side prepared statements (required for transaction pooling)
+  url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=require&prepareThreshold=${PGBOUNCER_PREPARE_THRESHOLD:-0}
   user: ${POSTGRES_USER}
   password: ${POSTGRES_PASSWORD}
-
-  # HikariCP pool — talk to PgBouncer, so pool can be larger
-  maxSize: 30                        # PgBouncer handles the real PG connection limit
-  minSize: 10
+  maxSize: ${DB_POOL_MAX_SIZE:-20}
+  minSize: ${DB_POOL_MIN_SIZE:-5}
   maxWaitForConnection: 5s
   validationQuery: "SELECT 1"
   connectionTimeout: 5000
   idleTimeout: 600000
   maxLifetime: 1800000
-  # Disable server-side prepared statements — required for PgBouncer transaction mode
-  initializationQuery: "SET search_path=public"
 
 migrateOnStartup: true
-ageEnabled: ${MARQUEZ_AGE_ENABLED:-false}  # false for Flex Server (no AGE support)
+ageEnabled: ${MARQUEZ_AGE_ENABLED:-true}
 
 logging:
-  level: WARN                        # NOT DEBUG — this is the most impactful single change
+  level: WARN
   appenders:
     - type: console
       logFormat: "%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n"
   loggers:
-    marquez: INFO                    # Marquez service-level events (starts, errors)
-    marquez.db: WARN                 # SQL only on warnings — DEBUG is 100M lines/day at 1M events
+    marquez: INFO
+    marquez.db: WARN
     org.jdbi: WARN
     org.postgresql: WARN
     org.eclipse.jetty: WARN
@@ -379,87 +345,20 @@ spec:
           averageUtilization: 80
 ```
 
-### AGE Pod (V3 only — separate StatefulSet, NOT on Azure Flex Server)
-
-```yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: postgres-age
-spec:
-  serviceName: postgres-age
-  replicas: 1
-  selector:
-    matchLabels:
-      app: postgres-age
-  template:
-    spec:
-      containers:
-        - name: postgres-age
-          image: swar00pduth/postgres-age:14-latest
-          resources:
-            requests:
-              cpu: "2"
-              memory: "16Gi"         # AGE graph in-memory traversal needs RAM
-            limits:
-              cpu: "4"
-              memory: "32Gi"
-          env:
-            - name: POSTGRES_DB
-              value: marquez_graph
-            - name: PGDATA
-              value: /var/lib/postgresql/data/pgdata
-            - name: POSTGRES_SHARED_BUFFERS
-              value: "8GB"
-            - name: POSTGRES_WORK_MEM
-              value: "256MB"         # AGE graph queries need more work_mem than relational
-          args:
-            - postgres
-            - -c
-            - shared_buffers=8GB
-            - -c
-            - work_mem=256MB
-            - -c
-            - effective_cache_size=24GB
-            - -c
-            - max_connections=50    # Only Marquez V3 pods talk to this
-            - -c
-            - shared_preload_libraries=age,pg_stat_statements
-            - -c
-            - statement_timeout=15000
-          volumeMounts:
-            - name: postgres-age-data
-              mountPath: /var/lib/postgresql/data
-  volumeClaimTemplates:
-    - metadata:
-        name: postgres-age-data
-      spec:
-        accessModes: [ReadWriteOnce]
-        storageClassName: managed-premium  # Azure Premium SSD
-        resources:
-          requests:
-            storage: 200Gi           # Graph only — much smaller than relational store
-```
-
 ---
 
 ## 5. Node Pool Sizing for AKS
+
+Only one node pool needed — Marquez API pods only. No separate database node pool
+(database is Azure managed).
 
 ```
 ┌──────────────────────────────────────────────────────┐
 │  Node Pool: marquez-api                              │
 │  VM SKU: Standard_D4ds_v5 (4 vCPU, 16 GB RAM)       │
-│  Count: 3 (min) → 8 (max with cluster autoscaler)   │
-│  Each node runs: 1 Marquez API pod + PgBouncer       │
+│  Count: 3 (min) → 10 (max with cluster autoscaler)  │
+│  Each node runs: 1 Marquez API pod                   │
 │  Taints: none (shared pool OK)                       │
-└──────────────────────────────────────────────────────┘
-
-┌──────────────────────────────────────────────────────┐
-│  Node Pool: postgres-age                             │
-│  VM SKU: Standard_E8s_v5 (8 vCPU, 64 GB RAM)        │
-│  Count: 1 (StatefulSet — no horizontal scale for PG) │
-│  Taints: dedicated=postgres-age:NoSchedule           │
-│  Tolerations: on AGE StatefulSet only                │
 └──────────────────────────────────────────────────────┘
 ```
 
@@ -467,14 +366,15 @@ spec:
 
 ## 6. Data Volume Projections at 1M Events/Day (2 Years)
 
-| Table | Row/day | Row size | 2-yr size | Action |
+| Table | Rows/day | Row size | 2-yr size | Action |
 |---|---|---|---|---|
 | lineage_events | 1,000,000 | ~200B | **146 GB** | Already indexed by run_date |
-| run_facets | **10,000,000** | ~150B | **1.1 TB** | **Partition urgently — V107** |
+| run_facets | **10,000,000** | ~150B | **1.1 TB** | **Partition urgently — V108** |
 | run_lineage_denormalized | 150,000 | ~500B | 54 GB | Manageable with partitions |
 | runs | 5,000 | ~300B | 2.1 GB | Small |
 | dataset_versions | 10,000 | ~200B | 5.5 GB | Small |
-| lineage_edges (new) | 30,000 | ~100B | 18 GB | Replace CTE reads |
+| lineage_edges (new) | 30,000 | ~100B | 18 GB | Replaces recursive CTE reads |
+| AGE graph (ag_catalog) | ~40,000 | ~200B | ~21 GB | Grows with lineage_edges |
 
 **`run_facets` at 1.1 TB is the immediate 2-year time bomb.**
 With 10 facets per event × 1M events/day = 10M rows/day × 730 days = **7.3 billion rows**.
@@ -482,7 +382,7 @@ This table must be range-partitioned by `lineage_event_time` before month 4.
 
 ```sql
 -- Run BEFORE run_facets hits 500M rows
--- Schedule as a one-time maintenance window (requires brief downtime or logical replication)
+-- Schedule as a one-time maintenance window
 CREATE TABLE run_facets_new (LIKE run_facets INCLUDING ALL)
     PARTITION BY RANGE (lineage_event_time);
 -- Monthly partitions, 12-month retention (facets are hot for 12 months, cold after)
@@ -496,11 +396,40 @@ CREATE TABLE run_facets_new (LIKE run_facets INCLUDING ALL)
 |---|---|---|---|
 | 1 | `logging.level: WARN` in production config | 5 min | 10–20% CPU freed immediately |
 | 2 | Gate denorm writes on START/COMPLETE/FAIL only (done) | done | 100× write IOPS reduction |
-| 3 | PgBouncer transaction pooling | 1 hour | Fixes connection exhaustion under Spark burst |
+| 3 | Built-in PgBouncer via server parameter + port 6432 | 15 min | Fixes connection exhaustion under Spark burst |
 | 4 | `statement_timeout=30s` on Azure Flex Server | 5 min | Kills runaway CTEs, frees connections |
 | 5 | Fix tautology bug `dvf.run_uuid = dvf.run_uuid` (done) | done | 50×+ response size reduction |
-| 6 | Partition `run_facets` by `lineage_event_time` | 1 day | Prevents 1.1 TB unpartitioned table |
-| 7 | Build `lineage_edges` table, move reads off recursive CTEs | 1 week | Eliminates BFS CPU cost entirely |
-| 8 | Move to `Standard_E8ds_v5` with `synchronous_commit=off` | 2 hours | 3× write throughput on Flex Server |
-| 9 | Add read replica for lineage GET queries | 2 hours | Write path isolated from read path |
-| 10 | V3 AGE pre-built graph (NOT live Cypher traversal) | 2 months | Long-term stable graph API |
+| 6 | UNION ALL CTE split + depth caps (done) | done | Eliminates index bypass in BFS queries |
+| 7 | Partition `run_facets` by `lineage_event_time` | 1 day | Prevents 1.1 TB unpartitioned table |
+| 8 | Build `lineage_edges` table, move reads off recursive CTEs | done (V107) | Eliminates BFS CPU cost entirely |
+| 9 | Move to `Standard_E8ds_v5` with `synchronous_commit=off` | 2 hours | 3× write throughput |
+| 10 | Add read replica for lineage GET queries | 2 hours | Write path isolated from read path |
+| 11 | V3 AGE pre-built graph (NOT live Cypher traversal) | 2 months | Long-term stable graph API |
+
+---
+
+## 8. Monitoring Queries
+
+```sql
+-- DEFAULT partition size alert — rows here mean a month partition was missed
+SELECT COUNT(*) FROM run_lineage_denormalized_default;
+SELECT COUNT(*) FROM run_parent_lineage_denormalized_default;
+
+-- lineage_edges growth rate
+SELECT run_date, COUNT(*) FROM lineage_edges GROUP BY run_date ORDER BY run_date DESC LIMIT 30;
+
+-- run_facets size (track monthly)
+SELECT pg_size_pretty(pg_total_relation_size('run_facets'));
+SELECT COUNT(*) FROM run_facets;
+
+-- Slow query log check
+SELECT query, calls, total_exec_time/calls AS avg_ms, rows
+FROM pg_stat_statements
+WHERE total_exec_time/calls > 5000
+ORDER BY avg_ms DESC
+LIMIT 20;
+
+-- PgBouncer pool stats (query against Flex Server pgbouncer stats)
+-- Connect on port 6432 with user pgbouncer to the pgbouncer database
+-- SHOW POOLS; SHOW STATS; SHOW CLIENTS;
+```

--- a/docs/azure-production-config.md
+++ b/docs/azure-production-config.md
@@ -1,5 +1,4 @@
-# Marquez Production Config: Azure PostgreSQL Flex Server + AKS
-# Long-Term Lineage Strategy: V1/V2 vs V3 (AGE) vs Pre-built Graph
+# Marquez Production Config: Azure PostgreSQL Flex Server PG17
 
 ## Architecture Overview
 
@@ -17,21 +16,20 @@
                             │ JDBC (port 6432 — built-in PgBouncer)
                             ▼
 ┌──────────────────────────────────────────────────────────────────┐
-│  Azure PostgreSQL Flexible Server — PG 17 + AGE extension        │
+│  Azure PostgreSQL Flexible Server — PG 17                        │
 │                                                                  │
 │  Built-in PgBouncer (transaction mode, port 6432)                │
 │  ↓ fans out to ↓                                                 │
 │  PostgreSQL 17 backend (port 5432)                               │
 │                                                                  │
-│  Extensions: age, pg_stat_statements                             │
+│  Extensions: pg_stat_statements                                  │
 │  V1 tables:  runs, jobs, datasets, lineage_events, run_facets    │
 │  V2 tables:  run_lineage_denormalized, dataset_denormalized, ... │
-│  V3 graph:   ag_catalog (Apache AGE graph for Cypher queries)    │
 │  Pre-mat:    lineage_edges (BFS adjacency — replaces CTE reads)  │
 └──────────────────────────────────────────────────────────────────┘
 ```
 
-Single database instance serves all three API versions. No separate pod for AGE.
+Single database instance serves V1 and V2 API versions.
 PgBouncer is Azure-managed via server parameter — no sidecar or extra Deployment needed.
 
 ---
@@ -65,26 +63,7 @@ The `logging.level: DEBUG` in your `config.yml` alone at 1M events/day generates
 
 ---
 
-## 2. Long-Term Strategy: Which API Version Wins?
-
-### The Honest Answer
-
-**V2 wins for the next 12–18 months. V3 (AGE with pre-built graph) wins long-term.**
-
-```
-                    Now        6 months      18 months
-V1 (normalized)     ████       ██            █         (keep for writes, retire from reads)
-V2 (denorm tables)  ████       ████████      ████████  (primary read path)
-V3 AGE live CTE     ██         ██            ░░        (same CTE problem, just in Cypher)
-V3 AGE pre-built    ░░         ████          ████████  (target end state)
-```
-
-### Why V3 Live Cypher Doesn't Solve the Problem
-
-Cypher `MATCH (a)-[*1..10]->(b)` is STILL a live BFS traversal of the graph —
-it just uses graph indexes instead of recursive CTEs. At depth=10 on a graph
-with 5,000 new nodes per day × 730 days = 3.65M nodes, Cypher traversal has
-the same fan-out explosion problem as the SQL recursive CTE.
+## 2. Performance Strategy
 
 ### The Fix: Pre-Built Lineage Graph (Pre-Materialized Edges)
 
@@ -102,8 +81,7 @@ each milliseconds. No OOM risk, no planner problem, cacheable per level.
 ```
 Phase 1 (done)   — Fix recursive CTE OR→UNION, depth caps, tautology bug, write churn
 Phase 2 (done)   — Add lineage_edges materialized table (V107 migration)
-Phase 3 (6mo)    — V2 reads use lineage_edges instead of recursive CTE
-Phase 4 (18mo)   — V3 AGE graph populated from lineage_edges (pre-built, not live-traversed)
+Phase 3 (6mo)    — V2 reads use lineage_edges BFS-in-Java instead of recursive CTE
 ```
 
 ---
@@ -121,87 +99,113 @@ Phase 4 (18mo)   — V3 AGE graph populated from lineage_edges (pre-built, not l
 **Storage:** Premium SSD v2, 500 GB minimum, IOPS provisioned at 5,000 initially.
 Enable auto-grow. At 1M events/day the lineage_events table grows ~150 GB/year.
 
-### Built-in PgBouncer (Server Parameter — No Sidecar Needed)
+### Built-in PgBouncer
 
-Enable PgBouncer as a server parameter in the Azure Portal:
+Enable via Azure Portal: **Flexible Server → Server Parameters → search "pgbouncer"**
+
+When `pgbouncer.enabled = ON`, PgBouncer listens on **port 6432** on the same hostname.
+Your JDBC URL must use port 6432 (NOT 5432).
+
+`prepareThreshold=0` disables server-side prepared statements — required for
+PgBouncer transaction mode. Set `PGBOUNCER_PREPARE_THRESHOLD=0` in your Helm values.
+
+### Flex Server Parameter Reference
+
+Navigate to: **Azure Portal → Flexible Server → Server Parameters → search `<name>` → Save**
+
+Parameters marked *(static)* require a server restart after saving.
+
+#### PgBouncer
+
+| Parameter | Value | Notes |
+|---|---|---|
+| pgbouncer.enabled | ON | Built-in — no sidecar needed |
+| pgbouncer.pool_mode | transaction | **CRITICAL** — Marquez uses connection-per-request |
+| pgbouncer.max_client_conn | 500 | 3 pods × 20 HikariCP + headroom |
+| pgbouncer.default_pool_size | 50 | Server-side pool per DB/user pair |
+| pgbouncer.min_pool_size | 10 | Keeps warm connections alive |
+| pgbouncer.server_idle_timeout | 600 | Seconds before idle server connection closed |
+| pgbouncer.query_timeout | 30 | Seconds; matches statement_timeout below |
+
+#### Memory *(static — restart required)*
+
+| Parameter | Value | Unit | Notes |
+|---|---|---|---|
+| shared_buffers | 16384 | MB | 25% of 64 GB RAM |
+| effective_cache_size | 49152 | MB | 75% of 64 GB RAM (planner hint, dynamic) |
+| work_mem | 131072 | kB | 128 MB per sort; recursive CTEs use multiple |
+| maintenance_work_mem | 2097152 | kB | 2 GB for VACUUM and index builds |
+
+#### WAL
+
+| Parameter | Value | Unit | Notes |
+|---|---|---|---|
+| wal_buffers | 65536 | kB | 64 MB *(static)* |
+| checkpoint_completion_target | 0.9 | — | Spreads checkpoint I/O |
+| min_wal_size | 2048 | MB | |
+| max_wal_size | 8192 | MB | |
+| synchronous_commit | off | — | Safe for lineage events; use `on` for run-state transitions |
+
+#### I/O (Premium SSD v2)
+
+| Parameter | Value | Notes |
+|---|---|---|
+| random_page_cost | 1.1 | NVMe-equivalent; default 4 is for spinning disk |
+| effective_io_concurrency | 200 | Parallel I/O requests the SSD can handle |
+
+#### Parallelism
+
+| Parameter | Value | Notes |
+|---|---|---|
+| max_worker_processes | 8 | Matches vCores *(static)* |
+| max_parallel_workers | 8 | |
+| max_parallel_workers_per_gather | 4 | Half vCores |
+
+#### Connections
+
+| Parameter | Value | Notes |
+|---|---|---|
+| max_connections | 100 | PgBouncer sits in front; ~50 real PG connections used |
+
+#### Autovacuum (critical for high-write tables)
+
+| Parameter | Value | Unit | Notes |
+|---|---|---|---|
+| autovacuum_max_workers | 6 | — | Default 3; extra workers for run_facets, runs |
+| autovacuum_vacuum_scale_factor | 0.02 | — | Vacuum at 2% dead tuples (default 20%) |
+| autovacuum_analyze_scale_factor | 0.01 | — | Analyze at 1% new tuples |
+| autovacuum_vacuum_cost_delay | 2 | ms | Reduce throttling; default 2ms already on PG17 |
+| autovacuum_vacuum_cost_limit | 800 | — | Higher = faster vacuum; default 200 |
+| autovacuum_naptime | 30 | s | Check tables every 30 s; default 60 |
+
+#### Timeouts
+
+| Parameter | Value | Unit | Notes |
+|---|---|---|---|
+| lock_timeout | 5000 | ms | Prevents cascading lock waits |
+| statement_timeout | 30000 | ms | **Kills runaway lineage CTEs** |
+| idle_in_transaction_session_timeout | 10000 | ms | Clears stuck transactions |
+
+#### Logging
+
+| Parameter | Value | Notes |
+|---|---|---|
+| log_min_duration_statement | 5000 | ms; captures queries slower than 5 s |
+| log_connections | off | Reduces log noise at 1M events/day |
+| log_disconnections | off | |
+
+#### Extensions *(static — restart required)*
+
+| Parameter | Value | Notes |
+|---|---|---|
+| shared_preload_libraries | pg_stat_statements | |
+| pg_stat_statements.track | all | |
+| track_activity_query_size | 4096 | Bytes |
+
+### Production JDBC URL
 
 ```
-Server parameters to set in Azure Portal:
-  pgbouncer.enabled              = true
-  pgbouncer.pool_mode            = transaction      ← CRITICAL for correctness
-  pgbouncer.max_client_conn      = 500
-  pgbouncer.default_pool_size    = 50
-  pgbouncer.min_pool_size        = 10
-  pgbouncer.server_idle_timeout  = 600
-  pgbouncer.query_timeout        = 30
-```
-
-When enabled, PgBouncer listens on **port 6432** on the same hostname as your
-Flex Server. Your JDBC URL must point to port 6432, NOT 5432:
-
-```
-jdbc:postgresql://<flex-server-hostname>:6432/marquez?sslmode=require&prepareThreshold=0
-```
-
-`prepareThreshold=0` disables server-side prepared statements, which is required
-for PgBouncer transaction mode. This is already set in the Helm chart via
-`PGBOUNCER_PREPARE_THRESHOLD=0`.
-
-### PostgreSQL Server Parameters (set in Azure Portal → Server Parameters)
-
-```
-# Memory
-shared_buffers                    = 16384    (MB — 25% of 64 GB RAM)
-effective_cache_size              = 49152    (MB — 75% of 64 GB RAM)
-work_mem                          = 128      (MB — PER SORT per connection; recursive CTEs use multiple)
-maintenance_work_mem              = 2048     (MB — for VACUUM and index builds)
-temp_buffers                      = 32       (MB)
-
-# Write performance
-wal_buffers                       = 64       (MB)
-checkpoint_completion_target      = 0.9
-min_wal_size                      = 2048     (MB)
-max_wal_size                      = 8192     (MB)
-synchronous_commit                = off      (safe for lineage events — eventual consistency acceptable)
-                                             # IMPORTANT: set to 'on' for run state transitions
-
-# I/O (Premium SSD v2)
-random_page_cost                  = 1.1      (SSD — lower than spinning disk default of 4)
-effective_io_concurrency          = 200      (SSD)
-seq_page_cost                     = 1.0
-
-# Parallelism
-max_worker_processes              = 8        (= vCores)
-max_parallel_workers              = 8
-max_parallel_workers_per_gather   = 4
-parallel_tuple_cost               = 0.1
-
-# Connections (PgBouncer sits in front; ~50 real PostgreSQL connections from PgBouncer)
-max_connections                   = 100
-
-# Autovacuum — critical for high-write tables
-autovacuum_max_workers            = 6
-autovacuum_vacuum_scale_factor    = 0.02     (vacuum when 2% of table modified — default is 20%)
-autovacuum_analyze_scale_factor   = 0.01
-autovacuum_vacuum_cost_delay      = 2        (ms — aggressive vacuum pace)
-autovacuum_vacuum_cost_limit      = 800      (default 200 — allows faster VACUUM)
-autovacuum_naptime                = 30       (seconds between autovacuum checks)
-
-# Query behavior
-lock_timeout                      = 5000     (ms)
-statement_timeout                 = 30000    (ms — kill queries >30s; prevents runaway lineage CTEs)
-idle_in_transaction_session_timeout = 10000 (ms)
-
-# Logging — INFO only in production
-log_min_duration_statement        = 5000     (ms — only log queries >5s)
-log_connections                   = off
-log_disconnections                = off
-log_duration                      = off
-
-# Extensions (set shared_preload_libraries in Azure Portal)
-shared_preload_libraries          = pg_stat_statements,age
-pg_stat_statements.track          = all
-track_activity_query_size         = 4096
+jdbc:postgresql://<flex-server-hostname>:6432/<db>?sslmode=require&prepareThreshold=0&socketTimeout=30&connectTimeout=5&loginTimeout=5
 ```
 
 ---
@@ -225,11 +229,11 @@ marquez:
       memory: "5Gi"
     limits:
       cpu: "4"
-      memory: "8Gi"                  # JVM heap capped at 5Gi, overhead ~2.5Gi → fits in 8Gi limit
+      memory: "8Gi"         # JVM heap capped at 5Gi, overhead ~2.5Gi → fits in 8Gi
 
   db:
     host: <flex-server-hostname>
-    port: 6432                        # ← PgBouncer port (NOT 5432)
+    port: 6432              # PgBouncer port (NOT 5432)
     name: marquez
     user: buendia
     # password: set via existingSecretName
@@ -247,9 +251,8 @@ marquez:
   logLevel: "WARN"
   dbPoolMaxSize: 20
   dbPoolMinSize: 5
-  pgbouncerPrepareThreshold: "0"     # Required for PgBouncer transaction mode
-
-  ageEnabled: true                   # AGE is enabled on Azure Flex Server PG 17
+  pgbouncerPrepareThreshold: "0"   # Required for PgBouncer transaction mode
+  ageEnabled: false
 
   podAnnotations:
     prometheus.io/scrape: "true"
@@ -265,55 +268,6 @@ marquez:
             labelSelector:
               matchLabels:
                 app.kubernetes.io/component: marquez
-```
-
-### Marquez Config for Production (config.yml via ConfigMap)
-
-```yaml
-server:
-  applicationConnectors:
-    - type: http
-      port: ${MARQUEZ_PORT:-5000}
-      httpCompliance: RFC7230_LEGACY
-      acceptorThreads: 2
-      selectorThreads: 8
-  adminConnectors:
-    - type: http
-      port: ${MARQUEZ_ADMIN_PORT:-5001}
-  gzip:
-    enabled: true
-    minimumEntitySize: 256 bytes
-    bufferSize: 8KiB
-
-db:
-  driverClass: org.postgresql.Driver
-  # Port 6432 = Azure Flex Server built-in PgBouncer (transaction mode)
-  # prepareThreshold=0 disables server-side prepared statements (required for transaction pooling)
-  url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=require&prepareThreshold=${PGBOUNCER_PREPARE_THRESHOLD:-0}
-  user: ${POSTGRES_USER}
-  password: ${POSTGRES_PASSWORD}
-  maxSize: ${DB_POOL_MAX_SIZE:-20}
-  minSize: ${DB_POOL_MIN_SIZE:-5}
-  maxWaitForConnection: 5s
-  validationQuery: "SELECT 1"
-  connectionTimeout: 5000
-  idleTimeout: 600000
-  maxLifetime: 1800000
-
-migrateOnStartup: true
-ageEnabled: ${MARQUEZ_AGE_ENABLED:-true}
-
-logging:
-  level: WARN
-  appenders:
-    - type: console
-      logFormat: "%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n"
-  loggers:
-    marquez: INFO
-    marquez.db: WARN
-    org.jdbi: WARN
-    org.postgresql: WARN
-    org.eclipse.jetty: WARN
 ```
 
 ### HPA (Horizontal Pod Autoscaler)
@@ -349,9 +303,6 @@ spec:
 
 ## 5. Node Pool Sizing for AKS
 
-Only one node pool needed — Marquez API pods only. No separate database node pool
-(database is Azure managed).
-
 ```
 ┌──────────────────────────────────────────────────────┐
 │  Node Pool: marquez-api                              │
@@ -374,18 +325,16 @@ Only one node pool needed — Marquez API pods only. No separate database node p
 | runs | 5,000 | ~300B | 2.1 GB | Small |
 | dataset_versions | 10,000 | ~200B | 5.5 GB | Small |
 | lineage_edges (new) | 30,000 | ~100B | 18 GB | Replaces recursive CTE reads |
-| AGE graph (ag_catalog) | ~40,000 | ~200B | ~21 GB | Grows with lineage_edges |
 
 **`run_facets` at 1.1 TB is the immediate 2-year time bomb.**
-With 10 facets per event × 1M events/day = 10M rows/day × 730 days = **7.3 billion rows**.
+10 facets per event × 1M events/day = 10M rows/day × 730 days = **7.3 billion rows**.
 This table must be range-partitioned by `lineage_event_time` before month 4.
 
 ```sql
--- Run BEFORE run_facets hits 500M rows
--- Schedule as a one-time maintenance window
+-- Run BEFORE run_facets hits 500M rows (schedule as a maintenance window)
 CREATE TABLE run_facets_new (LIKE run_facets INCLUDING ALL)
     PARTITION BY RANGE (lineage_event_time);
--- Monthly partitions, 12-month retention (facets are hot for 12 months, cold after)
+-- Monthly partitions, 12-month active retention
 ```
 
 ---
@@ -397,14 +346,14 @@ CREATE TABLE run_facets_new (LIKE run_facets INCLUDING ALL)
 | 1 | `logging.level: WARN` in production config | 5 min | 10–20% CPU freed immediately |
 | 2 | Gate denorm writes on START/COMPLETE/FAIL only (done) | done | 100× write IOPS reduction |
 | 3 | Built-in PgBouncer via server parameter + port 6432 | 15 min | Fixes connection exhaustion under Spark burst |
-| 4 | `statement_timeout=30s` on Azure Flex Server | 5 min | Kills runaway CTEs, frees connections |
+| 4 | `statement_timeout=30s` on Flex Server | 5 min | Kills runaway CTEs, frees connections |
 | 5 | Fix tautology bug `dvf.run_uuid = dvf.run_uuid` (done) | done | 50×+ response size reduction |
 | 6 | UNION ALL CTE split + depth caps (done) | done | Eliminates index bypass in BFS queries |
 | 7 | Partition `run_facets` by `lineage_event_time` | 1 day | Prevents 1.1 TB unpartitioned table |
-| 8 | Build `lineage_edges` table, move reads off recursive CTEs | done (V107) | Eliminates BFS CPU cost entirely |
-| 9 | Move to `Standard_E8ds_v5` with `synchronous_commit=off` | 2 hours | 3× write throughput |
-| 10 | Add read replica for lineage GET queries | 2 hours | Write path isolated from read path |
-| 11 | V3 AGE pre-built graph (NOT live Cypher traversal) | 2 months | Long-term stable graph API |
+| 8 | Build `lineage_edges` table, move reads off recursive CTEs | done (V107) | Eliminates BFS CPU cost at write time |
+| 9 | BFS-in-Java reads from `lineage_edges` | 1 week | Eliminates recursive CTE entirely from read path |
+| 10 | Move to `Standard_E8ds_v5` with `synchronous_commit=off` | 2 hours | 3× write throughput |
+| 11 | Add read replica for lineage GET queries | 2 hours | Write path isolated from read path |
 
 ---
 
@@ -418,18 +367,18 @@ SELECT COUNT(*) FROM run_parent_lineage_denormalized_default;
 -- lineage_edges growth rate
 SELECT run_date, COUNT(*) FROM lineage_edges GROUP BY run_date ORDER BY run_date DESC LIMIT 30;
 
--- run_facets size (track monthly)
+-- run_facets size (track monthly; action needed before 500M rows)
 SELECT pg_size_pretty(pg_total_relation_size('run_facets'));
 SELECT COUNT(*) FROM run_facets;
 
--- Slow query log check
+-- Slow query log (queries averaging > 5 s)
 SELECT query, calls, total_exec_time/calls AS avg_ms, rows
 FROM pg_stat_statements
 WHERE total_exec_time/calls > 5000
 ORDER BY avg_ms DESC
 LIMIT 20;
 
--- PgBouncer pool stats (query against Flex Server pgbouncer stats)
+-- PgBouncer pool stats
 -- Connect on port 6432 with user pgbouncer to the pgbouncer database
 -- SHOW POOLS; SHOW STATS; SHOW CLIENTS;
 ```

--- a/docs/mesh-lineage-perf-design.md
+++ b/docs/mesh-lineage-perf-design.md
@@ -66,27 +66,62 @@ log.debug("DatasetVersionIds found in run data: {}", datasetVersionIds);
 
 **Impact:** At 1M events/day with log level INFO (typical in prod), this serializes a large `Set<DatasetVersionId>` to string on every lineage READ request, wasting CPU.
 
-### BUG-03: `OR` condition in recursive JOIN prevents index use
+### BUG-03: `OR` condition in recursive JOIN — and why it CANNOT be split into two arms
 
-**File:** `api/src/main/java/marquez/db/LineageDao.java:309`
+**File:** `api/src/main/java/marquez/db/LineageDao.java` (four recursive CTEs:
+`getRunLineage`, `getRunLineageWithFacets`, `getParentRunLineage`,
+`getParentRunLineageWithFacets`)
 
 ```sql
--- CURRENT — forces BitmapOr, may degrade to seq scan on the CTE work table
+-- The traversal join matches a neighbouring run in either direction:
 JOIN lineage l
   ON (io.input_version_uuid = l.output_version_uuid
       OR io.output_version_uuid = l.input_version_uuid)
-
--- SHOULD BE (two separate arms — planner can use each index independently)
-JOIN lineage l ON io.input_version_uuid = l.output_version_uuid
-  WHERE l.depth < :depth
-UNION ALL
-SELECT ... FROM run_lineage_denormalized io
-JOIN lineage l ON io.output_version_uuid = l.input_version_uuid
-  AND io.run_uuid != l.run_uuid
-  WHERE l.depth < :depth
+ AND io.run_uuid != l.run_uuid
 ```
 
-**Impact:** At scale, PostgreSQL's recursive CTE work table is not indexed. The OR join causes a sequential scan of the materialized CTE at every recursion level.
+**Original (incorrect) proposal — DO NOT USE.** An earlier draft proposed
+splitting this into two `UNION ALL` arms so each could use a dedicated index:
+
+```sql
+-- base
+SELECT ... 0 AS depth FROM run_lineage_denormalized r WHERE r.run_uuid IN (...)
+UNION ALL
+SELECT ... FROM run_lineage_denormalized io JOIN lineage l    -- upstream arm
+  ON io.input_version_uuid = l.output_version_uuid ...
+UNION ALL
+SELECT ... FROM run_lineage_denormalized io JOIN lineage l    -- downstream arm
+  ON io.output_version_uuid = l.input_version_uuid ...
+```
+
+**This does not work.** A PostgreSQL recursive CTE allows **exactly one
+recursive term**. With three branches PostgreSQL groups them left-associatively
+as `(base UNION ALL upstream) UNION ALL downstream`, which places a self
+reference (`lineage` in the upstream arm) inside what it treats as the
+*non-recursive* term, raising at execution time:
+
+```
+ERROR: recursive reference to query "lineage" must not appear within
+its non-recursive term
+```
+
+This was implemented, broke all 19 run/parent-run lineage tests, and was
+reverted. The correct, legal form keeps **one** recursive arm with the OR join.
+
+**Actual mitigation.** Index utilisation comes from the large side of the join
+(`run_lineage_denormalized io`), not from rewriting the CTE structure. With the
+V106 indexes (`idx_run_lineage_denorm_input_version`,
+`idx_run_lineage_denorm_output_version`, plus the `out_to_in` / `in_to_out`
+composites) PostgreSQL satisfies the OR via a **BitmapOr of two index scans** on
+`io` — not a sequential scan. The `lineage l` work table is small per recursion
+level and is scanned in memory; that is normal for recursive CTEs and is not the
+bottleneck. The truly index-accelerated traversal requires a different data
+model — see §3f (lineage_edges BFS) and §2c (GIN array overlap), both of which
+still use a **single** recursive/iterative step.
+
+**Impact (uncorrected):** none beyond the BitmapOr cost; the earlier claim of a
+"sequential scan at every recursion level" overstated the issue for the indexed
+`io` table.
 
 ### BUG-04: V2 lineage falls back to V1 for run/dataset-version nodes
 
@@ -214,7 +249,10 @@ CREATE TABLE run_lineage_summary (
 | Proposed row-per-run | 5,000 | ~1KB | ~5 MB | ~3.6 GB |
 | Reduction | **30×** | — | **15×** | **15×** |
 
-**Recursive CTE becomes simpler:**
+**Recursive CTE becomes simpler — but must keep a SINGLE recursive term**
+(see BUG-03). Both traversal directions go in **one** arm, OR-combined; the GIN
+indexes on the two array columns let PostgreSQL satisfy the OR with a BitmapOr of
+two GIN scans on the large `run_lineage_summary io` side:
 
 ```sql
 WITH RECURSIVE lineage AS (
@@ -226,18 +264,15 @@ WITH RECURSIVE lineage AS (
 
     UNION ALL
 
-    -- upstream: next run's outputs overlap this run's inputs
+    -- ONE recursive arm, both directions OR-combined (two UNION ALL arms that
+    -- each reference `lineage` are rejected: "recursive reference ... must not
+    -- appear within its non-recursive term").
+    --   upstream:   io.output_version_uuids && l.input_version_uuids
+    --   downstream: io.input_version_uuids  && l.output_version_uuids
     SELECT io.run_uuid, io.input_version_uuids, io.output_version_uuids, l.depth + 1
     FROM run_lineage_summary io, lineage l
-    WHERE io.output_version_uuids && l.input_version_uuids   -- GIN overlap operator
-      AND io.run_uuid != l.run_uuid
-      AND l.depth < :depth
-      AND io.run_date >= :minDate::date AND io.run_date <= :maxDate::date
-    UNION ALL
-    -- downstream: next run's inputs overlap this run's outputs
-    SELECT io.run_uuid, io.input_version_uuids, io.output_version_uuids, l.depth + 1
-    FROM run_lineage_summary io, lineage l
-    WHERE io.input_version_uuids && l.output_version_uuids
+    WHERE (io.output_version_uuids && l.input_version_uuids
+           OR io.input_version_uuids && l.output_version_uuids)   -- GIN overlap
       AND io.run_uuid != l.run_uuid
       AND l.depth < :depth
       AND io.run_date >= :minDate::date AND io.run_date <= :maxDate::date
@@ -352,6 +387,66 @@ Recursive CTEs on large graphs consume unbounded memory. Set per-transaction lim
 handle.execute("SET LOCAL work_mem = '128MB'");
 handle.execute("SET LOCAL statement_timeout = '30s'");
 ```
+
+`SET LOCAL` only takes effect inside an explicit transaction, so the recursive
+query and the `SET LOCAL` statements must run on the same `Handle` within a
+`jdbi.inTransaction(...)` block — a plain `@SqlQuery` on an on-demand DAO opens
+its own connection and the setting would not apply.
+
+### 3f. Pre-materialized `lineage_edges` BFS (the index-accelerated read path)
+
+The recursive CTE is bounded by the row-per-pair model and the single-recursive
+-term rule (BUG-03). The genuinely index-accelerated traversal replaces the CTE
+with a pre-computed adjacency table walked level-by-level in application code —
+the OpenMetadata pattern, kept inside PostgreSQL.
+
+**Status:** the table and the **write path are implemented** (V107 +
+`DenormalizedLineageService.populateLineageEdgesForRun`), populated at
+COMPLETE/FAIL/ABORT time and back-filled by V107. The **read path is NOT yet
+wired** — `lineage_edges` is currently write-only; lineage reads still issue the
+recursive CTE.
+
+**Schema (V107, shipped).** Each row is one hop between a run and a
+dataset_version:
+
+```sql
+lineage_edges (
+  from_node_id UUID, from_type TEXT,   -- 'run' | 'dataset_version'
+  to_node_id   UUID, to_type   TEXT,
+  edge_type    TEXT,                    -- 'PRODUCES' | 'CONSUMES'
+  run_uuid     UUID, run_date  DATE,
+  PRIMARY KEY (from_node_id, to_node_id, edge_type)
+)
+-- idx_lineage_edges_downstream (from_node_id, to_type, run_date DESC)
+-- idx_lineage_edges_upstream   (to_node_id,   from_type, run_date DESC)
+```
+
+**Read algorithm (to implement in Java).** Breadth-first, one indexed batch
+query per depth level instead of a single exponential recursive CTE:
+
+```
+frontier = { seed run/dataset-version node ids }
+visited  = {}
+for level in 0..depth:
+    next = SELECT to_node_id   FROM lineage_edges WHERE from_node_id = ANY(:frontier)   -- downstream
+           UNION
+           SELECT from_node_id FROM lineage_edges WHERE to_node_id   = ANY(:frontier)   -- upstream
+    frontier = next - visited
+    visited += next
+    if frontier empty: break
+```
+
+Each level is a single index range scan keyed on `from_node_id` / `to_node_id`
+(`= ANY(array)`), so cost is O(edges-touched), not O(graph^depth). Node/edge
+hydration (job names, dataset metadata, optional facets) is a second batched
+lookup over `visited`, reusing the existing entity-denorm queries so the emitted
+`Lineage` graph is byte-for-byte identical to the CTE output (required to keep
+the V1/V2 parity tests green).
+
+**Caveat:** this is a substantial read-path change. Because it must reproduce the
+exact graph shape the recursive CTE returns, it has to be validated against the
+`LineageResourceV1V2ParityIT` / `LineageServiceTest` suites before it can replace
+the CTE; until then it ships behind a flag and the CTE remains the default.
 
 ---
 
@@ -534,37 +629,41 @@ These must match V1 signature before V3 is production-ready.
 
 ## 8. Implementation Phases
 
+**Status legend:** ✅ done · 🟡 partial · ❌ not started · ⛔ withdrawn (see note)
+
 ### Phase 1 — Immediate (Days 1–3, zero schema change)
 
-| # | Change | File | Impact |
-|---|---|---|---|
-| P1-1 | Fix `dvf.run_uuid = dvf.run_uuid` tautology | `LineageDao.java:651` | Correct facets data |
-| P1-2 | Change `log.info` → `log.debug` on hot path | `LineageService.java:537,587-590` | CPU reduction |
-| P1-3 | Gate `populateDenormalizedEntitiesForEvent` on eventType | `OpenLineageService.java:179` | 200× write IOPS reduction |
-| P1-4 | Add `statement_timeout='30s'` to lineage DAO calls | `LineageDao.java` | Prevent runaway queries |
-| P1-5 | Add depth cap (max 10 V1, max 20 V2) in service layer | `LineageService.java` | Prevent OOM |
+| # | Change | File | Impact | Status |
+|---|---|---|---|---|
+| P1-1 | Fix `dvf.run_uuid = dvf.run_uuid` tautology | `LineageDao.java` | Correct facets data | ✅ |
+| P1-2 | Change `log.info` → `log.debug` on hot path | `LineageService.java` | CPU reduction | ✅ |
+| P1-3 | Gate `populateDenormalizedEntitiesForEvent` on eventType | `OpenLineageService.java` | 200× write IOPS reduction | ✅ |
+| P1-4 | Add `statement_timeout='30s'` / `work_mem` to lineage queries | `LineageDao` / `LineageService` | Prevent runaway queries | ❌ (needs `inTransaction` wrapper, see §3e) |
+| P1-5 | Add depth cap (max 10 V1, max 20 V2) in service layer | `LineageService.java` | Prevent OOM | ✅ |
 
 ### Phase 2 — Short-term (Weeks 1–2, schema additive)
 
-| # | Change | File | Impact |
-|---|---|---|---|
-| P2-1 | Add `DEFAULT` partition to run_lineage_denormalized | V106 migration | Prevent hard insert errors |
-| P2-2 | Add missing indexes (runs.parent_run_uuid, etc.) | V107 migration | Read performance |
-| P2-3 | Fix OR join → UNION ALL in recursive CTE | `LineageDao.java:307-313` | Index utilization |
-| P2-4 | Fix V2 run-type node fallback | `LineageService.java:202` | V2 parity |
-| P2-5 | Remove silent V2→V1 dataset fallback | `LineageService.java:253` | V2 correctness |
-| P2-6 | Partition `run_facets` table | V108 migration | 7.3B row problem |
-| P2-7 | Upsert only on state change (`WHERE ... IS DISTINCT FROM`) | `DenormalizedLineageService.java` | WAL reduction |
+| # | Change | File | Impact | Status |
+|---|---|---|---|---|
+| P2-1 | Add `DEFAULT` partition to run_lineage_denormalized | V106 migration | Prevent hard insert errors | ✅ |
+| P2-2 | Add missing indexes (runs.parent_run_uuid, etc.) | V106 migration | Read performance | ✅ |
+| P2-3 | ~~Fix OR join → UNION ALL in recursive CTE~~ | `LineageDao.java` | Index utilization | ⛔ withdrawn — illegal in a recursive CTE (BUG-03); single-arm OR + V106 indexes retained instead |
+| P2-4 | Fix V2 run-type node fallback (depth cap respected via `lineageImpl`) | `LineageService.java` | V2 parity | ✅ |
+| P2-5 | Remove silent V2→V1 dataset fallback | `LineageService.java` | V2 correctness | ❌ |
+| P2-6 | Partition `run_facets` table | V108 migration | 7.3B row problem | ❌ (tracked as TODO in V107) |
+| P2-7 | Upsert only on state change (`WHERE ... IS DISTINCT FROM`) | `DenormalizedLineageService.java` | WAL reduction | ❌ |
+| P2-8 | `lineage_edges` adjacency table + write path | V107 / `DenormalizedLineageService.java` | Enables §3f BFS read path | 🟡 write done, read not wired |
 
 ### Phase 3 — Medium-term (Month 1, schema replacement)
 
-| # | Change | Impact |
-|---|---|---|
-| P3-1 | Create `run_lineage_summary` (1 row/run, array-based) | 30× storage reduction, simpler recursive CTE |
-| P3-2 | Migrate V1 recursive CTE to use new schema | Query simplification |
-| P3-3 | Implement partition detach/archive job | 2-year retention enforcement |
-| P3-4 | Add `job_denormalized.namespace_name` column | V2 correctness |
-| P3-5 | Make AGE writes async | V3 write latency |
+| # | Change | Impact | Status |
+|---|---|---|---|
+| P3-0 | Wire `lineage_edges` BFS-in-Java read path behind a flag (§3f) | Index-accelerated reads, replaces recursive CTE | ❌ |
+| P3-1 | Create `run_lineage_summary` (1 row/run, array-based + GIN) | 30× storage reduction, single-arm OR CTE (§2c) | ❌ |
+| P3-2 | Migrate V1 recursive CTE to use new schema | Query simplification | ❌ |
+| P3-3 | Implement partition detach/archive job | 2-year retention enforcement | ❌ |
+| P3-4 | Add `job_denormalized.namespace_name` column | V2 correctness | ❌ |
+| P3-5 | Make AGE writes async | V3 write latency | ❌ |
 
 ### Phase 4 — Long-term (Month 2+, API parity)
 

--- a/docs/mesh-lineage-perf-design.md
+++ b/docs/mesh-lineage-perf-design.md
@@ -400,11 +400,18 @@ The recursive CTE is bounded by the row-per-pair model and the single-recursive
 with a pre-computed adjacency table walked level-by-level in application code —
 the OpenMetadata pattern, kept inside PostgreSQL.
 
-**Status:** the table and the **write path are implemented** (V107 +
-`DenormalizedLineageService.populateLineageEdgesForRun`), populated at
-COMPLETE/FAIL/ABORT time and back-filled by V107. The **read path is NOT yet
-wired** — `lineage_edges` is currently write-only; lineage reads still issue the
-recursive CTE.
+**Status:** the table + write path are implemented (V107 +
+`DenormalizedLineageService.populateLineageEdgesForRun`). The **read path is wired
+behind a flag** (`LineageService.traverseRunLineageEdges` +
+`LineageDao.findLineageEdgeTargets`/`findLineageEdgeSources`), enabled by env
+`MARQUEZ_LINEAGE_USE_EDGE_BFS=true`, **default off** until V1/V2 parity is proven
+in CI. When off, the recursive CTE path is unchanged. The BFS resolves the
+reachable run set, then hydrates it at depth 0 via the existing `getRunLineage`,
+so the emitted graph is identical to the CTE (`LineageServiceTest
+.testRunLineage_edgeBfs_matchesRecursiveCte` asserts node-set parity at depths
+1/2/5). Each run hop = two edge hops (run→dataset_version→run), both directions
+followed to match the CTE's `input=output OR output=input` adjacency. Lookups
+pass the seed runs' `run_date` range to prune the RANGE→HASH partitions.
 
 **Schema (V107, shipped).** Each row is one hop between a run and a
 dataset_version:

--- a/docs/mesh-lineage-perf-design.md
+++ b/docs/mesh-lineage-perf-design.md
@@ -690,7 +690,7 @@ These must match V1 signature before V3 is production-ready.
 | P2-6 | Partition `run_facets` table | V108 migration | 7.3B row problem | ❌ (tracked as TODO in V107) |
 | P2-7 | Upsert only on state change (`WHERE ... IS DISTINCT FROM`) | `DenormalizedLineageService.java` | WAL reduction | ❌ |
 | P2-8 | `lineage_edges` adjacency table + write/read path | V107/V109 / `LineageService.java` | §3f BFS read path | ✅ write + read (run & job/dataset) wired behind `MARQUEZ_LINEAGE_USE_EDGE_BFS` |
-| P2-6 | Partition `run_facets` table | V108 migration | 7.3B row problem | ✅ |
+| P2-6 | Partition `run_facets` table | V108 + `RunFacetsPartitionBackfillJob` | 7.3B row problem | ✅ online cutover: inline swap ≤1 GiB; large tables dual-write trigger + background ctid-keyset copy + count-verified swap (never blocks startup) |
 
 ### Phase 3 — Medium-term (Month 1, schema replacement)
 

--- a/docs/mesh-lineage-perf-design.md
+++ b/docs/mesh-lineage-perf-design.md
@@ -1,0 +1,663 @@
+# Mesh Lineage Performance Design — V1 Hardening & V2/V3 Parity
+
+**Scope:** 1 million OpenLineage events/day (≈5,000 Spark job runs/day × 200 events/run), 2-year retention, PostgreSQL backend.
+
+---
+
+## 0. The Core Bottleneck: Spark Writes 200 Events Per Job
+
+Spark's OpenLineage integration emits one event per stage transition plus heartbeats. A typical run produces:
+- 1 `START` — no datasets yet
+- ~197 `RUNNING` — metrics updates; **lineage graph unchanged**
+- 1 `COMPLETE` or `FAIL` — full dataset lineage
+
+Every event today hits the same code path in `OpenLineageService`:
+
+```
+POST /api/v1/lineage
+  └─ updateMarquezModel()          ← always hits normalized tables
+  └─ populateDenormalizedEntitiesForEvent()  ← always upserts denorm tables
+```
+
+This means **198 of 200 events per Spark job are pure write churn** into `run_lineage_denormalized` and `run_parent_lineage_denormalized` — touching the same rows each time via `ON CONFLICT DO UPDATE` with identical data.
+
+### Write IOPS Math
+
+| Factor | Value |
+|---|---|
+| Job runs/day | 5,000 |
+| Spark events/run | 200 |
+| Avg datasets per run (inputs × outputs) | 10 × 3 = 30 rows in denorm |
+| Denorm table upserts/day | 5,000 × 200 × 30 = **30 million** |
+| Useful writes (only COMPLETE/FAIL) | 5,000 × 30 = **150,000** |
+| Write amplification factor | **200×** |
+
+Each upsert costs: index probe + heap fetch + row update + WAL write + 3 index updates.
+
+---
+
+## 1. Bug Inventory (Production Impact)
+
+### BUG-01: Tautology in `getDatasetVersionData` — always wrong facets
+
+**File:** `api/src/main/java/marquez/db/LineageDao.java:651`
+
+```sql
+-- CURRENT (always TRUE — never filters by dataset version)
+WHERE dvf.run_uuid = dvf.run_uuid
+
+-- SHOULD BE
+WHERE dvf.run_uuid = dv.run_uuid
+```
+
+**Impact:** Every dataset version returns ALL facets for every run that ever touched it, not just the run that produced that version. Causes massively bloated responses and wrong data.
+
+### BUG-02: `log.info()` on hot path serializes huge collections
+
+**File:** `api/src/main/java/marquez/service/LineageService.java:537`
+
+```java
+// CURRENT — serializes all dataset version IDs to string on EVERY request
+log.info("DatasetVersionIds found in run data: {}", datasetVersionIds);
+
+// SHOULD BE
+log.debug("DatasetVersionIds found in run data: {}", datasetVersionIds);
+```
+
+**Impact:** At 1M events/day with log level INFO (typical in prod), this serializes a large `Set<DatasetVersionId>` to string on every lineage READ request, wasting CPU.
+
+### BUG-03: `OR` condition in recursive JOIN prevents index use
+
+**File:** `api/src/main/java/marquez/db/LineageDao.java:309`
+
+```sql
+-- CURRENT — forces BitmapOr, may degrade to seq scan on the CTE work table
+JOIN lineage l
+  ON (io.input_version_uuid = l.output_version_uuid
+      OR io.output_version_uuid = l.input_version_uuid)
+
+-- SHOULD BE (two separate arms — planner can use each index independently)
+JOIN lineage l ON io.input_version_uuid = l.output_version_uuid
+  WHERE l.depth < :depth
+UNION ALL
+SELECT ... FROM run_lineage_denormalized io
+JOIN lineage l ON io.output_version_uuid = l.input_version_uuid
+  AND io.run_uuid != l.run_uuid
+  WHERE l.depth < :depth
+```
+
+**Impact:** At scale, PostgreSQL's recursive CTE work table is not indexed. The OR join causes a sequential scan of the materialized CTE at every recursion level.
+
+### BUG-04: V2 lineage falls back to V1 for run/dataset-version nodes
+
+**File:** `api/src/main/java/marquez/service/LineageService.java:202-204`
+
+```java
+// CURRENT — V2 optimization bypassed entirely for run-type nodes
+if (nodeId.isRunType() || nodeId.isDatasetVersionType()) {
+    return lineage(nodeId, depth, aggregateToParentRun, includeFacets); // ← V1 path
+}
+```
+
+**Impact:** V2 API returns no performance benefit when queried by run ID — the most common UI access pattern. V2 parity is broken.
+
+### BUG-05: `getDatasetDataV2` fallback creates silent inconsistency
+
+**File:** `api/src/main/java/marquez/service/LineageService.java:253-258`
+
+```java
+datasets.addAll(this.getDatasetDataV2(datasetIds));
+if (datasets.isEmpty()) {
+    datasets.addAll(this.getDatasetData(datasetIds)); // ← falls back to V1 normalized table
+}
+```
+
+**Impact:** If denorm tables are stale (e.g., event lag), V2 silently returns V1 data. The caller cannot know which path was taken. This causes inconsistency between V2 calls for the same node.
+
+### BUG-06: Unique constraint allows NULL accumulation
+
+**File:** V89 migration
+
+```sql
+UNIQUE (run_uuid, input_version_uuid, output_version_uuid, run_date)
+```
+
+In PostgreSQL, `(run_uuid, NULL, NULL, run_date)` is **not** considered a duplicate — each NULL row is treated as distinct. A `START` event with no datasets inserts a row with `NULL` version UUIDs; every subsequent RUNNING event inserts another duplicate NULL row because the constraint is not violated. This silently accumulates garbage rows.
+
+**Fix:** Add a partial unique index or use `COALESCE(input_version_uuid, '00000000-0000-0000-0000-000000000000')` in a unique expression index.
+
+---
+
+## 2. Write Path Redesign
+
+### 2a. Gate Denormalized Writes on Event Type
+
+The single highest-impact change: **only write to denormalized tables on terminal or lineage-changing events**.
+
+```java
+// OpenLineageService.java — inside the marquez.thenAccept() lambda
+
+private static final Set<String> LINEAGE_CHANGING_EVENT_TYPES =
+    Set.of("START", "COMPLETE", "FAIL", "ABORT");
+
+// Skip expensive denorm write for pure RUNNING metric events from Spark
+String eventType = event.getEventType() != null
+    ? event.getEventType().toUpperCase()
+    : "OTHER";
+
+boolean hasNewDatasets = (update.getInputs().isPresent() && !update.getInputs().get().isEmpty())
+    || (update.getOutputs().isPresent() && !update.getOutputs().get().isEmpty());
+
+if (LINEAGE_CHANGING_EVENT_TYPES.contains(eventType) || hasNewDatasets) {
+    denormalizedLineageService.populateDenormalizedEntitiesForEvent(
+        update.getNamespace().getUuid(), jobUuid, datasetUuids);
+}
+```
+
+**Expected IOPS reduction:** 200× → from 30M/day to ~150K/day meaningful writes.
+
+### 2b. Deduplicate Run Lineage Denorm Rows at Upsert
+
+The current upsert re-writes all columns on `ON CONFLICT`. Change to a conditional update that skips if nothing changed:
+
+```sql
+INSERT INTO run_lineage_denormalized (run_uuid, ..., run_date)
+VALUES (:runUuid, ..., :runDate)
+ON CONFLICT (run_uuid, COALESCE(input_version_uuid, uuid_nil()), 
+             COALESCE(output_version_uuid, uuid_nil()), run_date)
+DO UPDATE SET
+    state = EXCLUDED.state,
+    ended_at = EXCLUDED.ended_at,
+    updated_at = EXCLUDED.updated_at
+WHERE run_lineage_denormalized.state IS DISTINCT FROM EXCLUDED.state
+   OR run_lineage_denormalized.ended_at IS DISTINCT FROM EXCLUDED.ended_at;
+```
+
+The `WHERE` clause makes the update a no-op when nothing changed, eliminating WAL writes for redundant events.
+
+### 2c. Replace `run_lineage_denormalized` Row-per-Pair Model
+
+**Current problem:** The unique constraint `(run_uuid, input_version_uuid, output_version_uuid, run_date)` stores one row per input×output pair. A Spark job with 10 inputs and 3 outputs = 30 rows per run.
+
+**Better design:** Store one row per run_uuid with arrays:
+
+```sql
+-- TARGET SCHEMA for run_lineage_denormalized (V106)
+CREATE TABLE run_lineage_summary (
+    run_uuid          UUID        NOT NULL,
+    run_date          DATE        NOT NULL,
+    namespace_name    TEXT        NOT NULL,
+    job_name          TEXT        NOT NULL,
+    job_uuid          UUID,
+    job_version_uuid  UUID,
+    state             TEXT,
+    started_at        TIMESTAMPTZ,
+    ended_at          TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ,
+    updated_at        TIMESTAMPTZ,
+    parent_run_uuid   UUID,
+    -- Arrays replace the N×M row explosion
+    input_version_uuids  UUID[]  NOT NULL DEFAULT '{}',
+    output_version_uuids UUID[]  NOT NULL DEFAULT '{}',
+    -- Lightweight JSON payloads only — no facets
+    input_datasets    JSONB     NOT NULL DEFAULT '[]',
+    output_datasets   JSONB     NOT NULL DEFAULT '[]',
+    PRIMARY KEY (run_uuid, run_date)
+) PARTITION BY RANGE (run_date);
+```
+
+**Storage impact at 1M events/day (5,000 runs/day):**
+
+| Design | Rows/day | Row size | Storage/day | 2-year total |
+|---|---|---|---|---|
+| Current row-per-pair | 150,000 | ~500B | ~75 MB | ~54 GB |
+| Proposed row-per-run | 5,000 | ~1KB | ~5 MB | ~3.6 GB |
+| Reduction | **30×** | — | **15×** | **15×** |
+
+**Recursive CTE becomes simpler:**
+
+```sql
+WITH RECURSIVE lineage AS (
+    -- base
+    SELECT r.run_uuid, r.input_version_uuids, r.output_version_uuids, 0 AS depth
+    FROM run_lineage_summary r
+    WHERE r.run_uuid IN (<runIds>)
+      AND r.run_date >= :minDate::date AND r.run_date <= :maxDate::date
+
+    UNION ALL
+
+    -- upstream: next run's outputs overlap this run's inputs
+    SELECT io.run_uuid, io.input_version_uuids, io.output_version_uuids, l.depth + 1
+    FROM run_lineage_summary io, lineage l
+    WHERE io.output_version_uuids && l.input_version_uuids   -- GIN overlap operator
+      AND io.run_uuid != l.run_uuid
+      AND l.depth < :depth
+      AND io.run_date >= :minDate::date AND io.run_date <= :maxDate::date
+    UNION ALL
+    -- downstream: next run's inputs overlap this run's outputs
+    SELECT io.run_uuid, io.input_version_uuids, io.output_version_uuids, l.depth + 1
+    FROM run_lineage_summary io, lineage l
+    WHERE io.input_version_uuids && l.output_version_uuids
+      AND io.run_uuid != l.run_uuid
+      AND l.depth < :depth
+      AND io.run_date >= :minDate::date AND io.run_date <= :maxDate::date
+)
+SELECT DISTINCT ON (run_uuid) run_uuid, input_version_uuids, output_version_uuids, MIN(depth) AS depth
+FROM lineage
+GROUP BY run_uuid, input_version_uuids, output_version_uuids
+```
+
+**Required index:**
+
+```sql
+-- GIN index enables fast && (array overlap) operator
+CREATE INDEX idx_run_lineage_summary_input_versions
+    ON run_lineage_summary USING GIN (input_version_uuids);
+
+CREATE INDEX idx_run_lineage_summary_output_versions
+    ON run_lineage_summary USING GIN (output_version_uuids);
+
+CREATE INDEX idx_run_lineage_summary_run_uuid
+    ON run_lineage_summary (run_uuid, run_date);
+```
+
+---
+
+## 3. Read Path Redesign
+
+### 3a. Eliminate Extra Round-Trip for Partition Pruning
+
+**Current:** `LineageService.lineage()` makes TWO sequential DB calls:
+1. `getRunDateRange(runIds)` → hits `runs` table
+2. Actual lineage query with date bounds
+
+**Fix:** Store `run_date` in the initial `getLatestRunUuidsForJobV2()` and `getSeedRunUuidsForDatasetV2()` lookups — return it alongside run UUIDs. Alternatively, pass the date bounds from the HTTP request context (the UI knows the time range the user is browsing).
+
+```java
+// Add a record that carries both UUID and date
+record RunWithDate(UUID runUuid, LocalDate runDate) {}
+
+// getLatestRunUuidsForJobV2 returns Set<RunWithDate>
+// → no extra query needed for partition pruning
+```
+
+### 3b. Fix `getDatasetVersionData` N+1 and Tautology
+
+The method is called ONCE after the lineage query but fetches ALL dataset version data, including a full `JSONB_AGG` of facets. At large depth, a lineage graph may contain 200+ dataset versions, causing a large `IN (...)` list and massive JSON aggregation.
+
+**Fix — lazy facet loading:**
+
+```sql
+-- Fast path (no facets): covering index scan
+SELECT dv.uuid, d.type, d.name, d.physical_name, d.namespace_name,
+       d.source_name, d.description, dv.lifecycle_state,
+       dv.created_at, dv.uuid AS current_version_uuid, dv.version,
+       sv.schema_location, t.tags
+FROM dataset_versions dv
+INNER JOIN datasets_view d ON d.uuid = dv.dataset_uuid
+LEFT JOIN stream_versions sv ON sv.dataset_version_uuid = dv.uuid
+LEFT JOIN (...tags subquery...) t ON t.dataset_uuid = dv.dataset_uuid
+WHERE dv.uuid IN (<versions>)
+-- facets loaded separately ONLY when includeFacets is specified
+```
+
+### 3c. Eliminate `JSON_AGG(DISTINCT jsonb_build_object(...))` CPU Spike
+
+JSONB DISTINCT requires sorting by JSONB internal comparison (expensive). Replace with:
+
+```sql
+-- Use subquery to deduplicate before aggregation
+JSON_AGG(sub.obj) AS input_versions
+FROM (
+    SELECT DISTINCT ON (input_dataset_version_uuid)
+        jsonb_build_object(
+            'namespace', input_dataset_namespace,
+            'name', input_dataset_name,
+            'version', input_dataset_version,
+            'dataset_version_uuid', input_dataset_version_uuid
+        ) AS obj
+    FROM lineage
+    WHERE input_dataset_name IS NOT NULL
+    ORDER BY input_dataset_version_uuid
+) sub
+```
+
+`DISTINCT ON` with an ORDER BY is an O(n log n) sort on a UUID key — far cheaper than JSONB comparison.
+
+### 3d. Cap Depth and Response Size
+
+**Current:** No server-side depth cap. A client can request `depth=100`.
+
+**Fix — enforced caps per API version:**
+
+```java
+// LineageResource.java
+private static final int MAX_DEPTH_V1 = 10;
+private static final int MAX_DEPTH_V2 = 20;
+private static final int MAX_NODE_COUNT = 500;
+
+// After graph construction
+if (nodes.size() > MAX_NODE_COUNT) {
+    // Truncate to MAX_NODE_COUNT nodes, add a `truncated: true` meta field
+    log.warn("Lineage graph truncated: {} nodes exceeded max {}", nodes.size(), MAX_NODE_COUNT);
+}
+```
+
+### 3e. Add `work_mem` and `statement_timeout` Per Query
+
+Recursive CTEs on large graphs consume unbounded memory. Set per-transaction limits:
+
+```java
+// In LineageDao — before executing recursive lineage queries
+handle.execute("SET LOCAL work_mem = '128MB'");
+handle.execute("SET LOCAL statement_timeout = '30s'");
+```
+
+---
+
+## 4. V2 Parity Fixes
+
+### 4a. V2 Run-Type Nodes Must Use Denormalized Path
+
+```java
+// LineageService.lineageV2() — replace the fallback:
+
+public Lineage lineageV2(NodeId nodeId, int depth, boolean aggregateToParentRun,
+                          Set<String> includeFacets) {
+    if (nodeId.isRunType() || nodeId.isDatasetVersionType()) {
+        // V2 ALSO uses denormalized tables for run nodes — NOT a fallback to V1
+        Set<UUID> runIds = resolveRunIds(nodeId, aggregateToParentRun);
+        if (runIds.isEmpty()) return new Lineage(ImmutableSortedSet.of());
+        
+        RunDateRange dateRange = getRunDateRange(runIds);
+        String minDate = dateRange != null ? dateRange.minDate().toString() : null;
+        String maxDate = dateRange != null ? dateRange.maxDate().toString() : null;
+        
+        Set<RunData> runData = (aggregateToParentRun && hasChildRuns(runIds))
+            ? getParentRunLineage(runIds, depth, minDate, maxDate)
+            : getRunLineage(runIds, depth, minDate, maxDate);
+        
+        return toRunLineage(runData);
+    }
+    // ... job/dataset path continues as before
+}
+```
+
+### 4b. Remove Silent V2 → V1 Fallback for Dataset Data
+
+The fallback `if (datasets.isEmpty()) { datasets.addAll(this.getDatasetData(datasetIds)); }` in `lineageV2()` must be replaced with a proper error or explicit fallback indicator:
+
+```java
+datasets.addAll(this.getDatasetDataV2(datasetIds));
+if (datasets.isEmpty()) {
+    // Log as warning — denorm tables may be lagging
+    log.warn("V2 dataset lookup returned empty for {} UUIDs; denorm tables may be stale", 
+             datasetIds.size());
+    // Do NOT silently fall back — return the V2 response with empty datasets
+    // and let the client retry or show stale-state indicator
+}
+```
+
+### 4c. `job_denormalized` Missing `namespace_name`
+
+The V88 schema for `job_denormalized` stores `namespace_uuid` (not `namespace_name`). The `getLineageV2` query at LineageDao:700 selects `j.namespace_name`, which relies on a JOIN to `namespaces` not present in the query. This is a latent query error.
+
+**Fix:** Either add `namespace_name` as a denormalized column to `job_denormalized` (consistent with the dataset/run denorm design), or join to `namespaces` explicitly.
+
+---
+
+## 5. Data Retention — 2-Year Strategy
+
+### 5a. Automated Partition Lifecycle
+
+Use `pg_partman` or a Quartz job to:
+1. Create next month's partition on the 1st of each month (already exists in `PartitionManagementService`)
+2. **Detach partitions older than 24 months** from the parent table (they become standalone tables)
+3. `VACUUM ANALYZE` the detached partition
+4. Move to cold storage (S3 via `pg_partman` + `pg_dump`) or drop
+
+```sql
+-- Monthly maintenance job (add to PartitionManagementService)
+-- Detach partition from 25 months ago (keeps 2 years accessible, detaches the 25th)
+SELECT detach_monthly_partition('run_lineage_denormalized',
+    DATE_TRUNC('month', NOW() - INTERVAL '25 months')::date);
+```
+
+### 5b. Add a `DEFAULT` Partition as Safety Net
+
+```sql
+-- Add a catch-all partition — prevents hard errors for out-of-range dates
+CREATE TABLE run_lineage_denormalized_default
+    PARTITION OF run_lineage_denormalized DEFAULT;
+
+CREATE TABLE run_parent_lineage_denormalized_default
+    PARTITION OF run_parent_lineage_denormalized DEFAULT;
+```
+
+Alert when rows land in the DEFAULT partition — it means the partition creation job failed.
+
+### 5c. Normalized Table Retention
+
+The `lineage_events`, `runs`, `run_facets`, `dataset_versions`, and `run_states` tables are NOT partitioned. At 1M events/day × 730 days:
+
+| Table | Rows at 2 years |
+|---|---|
+| lineage_events | ~730M |
+| runs | ~3.65M (5,000/day) |
+| run_states | ~14.6M (4 states/run) |
+| run_facets | ~7.3B (at 10 facets/event × 200 events) |
+| dataset_versions | ~7.3M |
+
+**`run_facets` is the critical one**: at 10 facets/event × 1M events/day = 10M rows/day → **7.3 billion rows** over 2 years. This must be partitioned.
+
+```sql
+-- V106: Partition run_facets by lineage_event_time
+-- (requires data migration — do as background job)
+CREATE TABLE run_facets_partitioned (
+    LIKE run_facets INCLUDING ALL
+) PARTITION BY RANGE (lineage_event_time);
+```
+
+### 5d. Retention Policy Table
+
+```sql
+CREATE TABLE retention_policy (
+    table_name TEXT PRIMARY KEY,
+    retention_months INT NOT NULL,
+    action TEXT NOT NULL DEFAULT 'DROP', -- DROP or ARCHIVE
+    last_applied TIMESTAMPTZ
+);
+
+INSERT INTO retention_policy VALUES
+    ('run_lineage_denormalized', 24, 'DROP', NULL),
+    ('run_parent_lineage_denormalized', 24, 'DROP', NULL),
+    ('lineage_events', 24, 'DROP', NULL),
+    ('run_facets', 12, 'DROP', NULL);  -- facets only kept 12 months
+```
+
+---
+
+## 6. V3 / Apache AGE Design
+
+### Current Problem
+
+V3 ingestion is synchronous — writes to both relational store AND AGE graph in the same request:
+
+```java
+// V3 is BLOCKING — user waits for both relational + graph write
+CompletableFuture<Void> graphFuture = ... graphWriter.write(event, graphJdbi) ...
+CompletableFuture.allOf(relationalFuture, graphFuture).join(); // ← blocks
+```
+
+At 200 Spark events/job this doubles the write latency for V3.
+
+### Fix: Async AGE Graph Writes
+
+Move AGE graph writes to the same async executor as the denormalized table writes. Graph writes should never block the HTTP response:
+
+```java
+// AGE write — fire and forget, same pattern as denorm writes
+CompletableFuture.runAsync(() -> {
+    try {
+        graphWriter.write(event, graphJdbi);
+    } catch (Exception e) {
+        log.error("AGE graph write failed for run {}", runId, e);
+        // Increment metric for monitoring; do NOT throw
+    }
+}, executor);
+```
+
+### V3 Read Parity with V1
+
+V3 reads use Apache AGE Cypher queries. The current gap:
+1. V3 does not support `aggregateToParentRun`
+2. V3 does not support `includeFacets`
+3. V3 depth is hardcoded at 2 (vs configurable in V1/V2)
+
+These must match V1 signature before V3 is production-ready.
+
+---
+
+## 7. Missing Indexes
+
+| Index | Table | Columns | Reason |
+|---|---|---|---|
+| `idx_runs_parent_run_uuid` | `runs` | `parent_run_uuid` | `hasChildRuns()` does full scan |
+| `idx_run_facets_run_uuid` | `run_facets` | `run_uuid, name` | Already in V104 |
+| `idx_job_versions_io_is_current` | `job_versions_io_mapping` | `(is_current_job_version, job_uuid)` | V1 BFS scans entire table |
+| `idx_dataset_versions_run_uuid` | `dataset_versions` | `run_uuid` | `getUpstreamRuns` recursive join |
+| `idx_runs_input_mapping_run_uuid` | `runs_input_mapping` | `run_uuid` | `getUpstreamRuns` initial case |
+| `idx_run_lineage_summary_gin_in` | `run_lineage_summary` | `GIN(input_version_uuids)` | New schema array overlap |
+| `idx_run_lineage_summary_gin_out` | `run_lineage_summary` | `GIN(output_version_uuids)` | New schema array overlap |
+
+---
+
+## 8. Implementation Phases
+
+### Phase 1 — Immediate (Days 1–3, zero schema change)
+
+| # | Change | File | Impact |
+|---|---|---|---|
+| P1-1 | Fix `dvf.run_uuid = dvf.run_uuid` tautology | `LineageDao.java:651` | Correct facets data |
+| P1-2 | Change `log.info` → `log.debug` on hot path | `LineageService.java:537,587-590` | CPU reduction |
+| P1-3 | Gate `populateDenormalizedEntitiesForEvent` on eventType | `OpenLineageService.java:179` | 200× write IOPS reduction |
+| P1-4 | Add `statement_timeout='30s'` to lineage DAO calls | `LineageDao.java` | Prevent runaway queries |
+| P1-5 | Add depth cap (max 10 V1, max 20 V2) in service layer | `LineageService.java` | Prevent OOM |
+
+### Phase 2 — Short-term (Weeks 1–2, schema additive)
+
+| # | Change | File | Impact |
+|---|---|---|---|
+| P2-1 | Add `DEFAULT` partition to run_lineage_denormalized | V106 migration | Prevent hard insert errors |
+| P2-2 | Add missing indexes (runs.parent_run_uuid, etc.) | V107 migration | Read performance |
+| P2-3 | Fix OR join → UNION ALL in recursive CTE | `LineageDao.java:307-313` | Index utilization |
+| P2-4 | Fix V2 run-type node fallback | `LineageService.java:202` | V2 parity |
+| P2-5 | Remove silent V2→V1 dataset fallback | `LineageService.java:253` | V2 correctness |
+| P2-6 | Partition `run_facets` table | V108 migration | 7.3B row problem |
+| P2-7 | Upsert only on state change (`WHERE ... IS DISTINCT FROM`) | `DenormalizedLineageService.java` | WAL reduction |
+
+### Phase 3 — Medium-term (Month 1, schema replacement)
+
+| # | Change | Impact |
+|---|---|---|
+| P3-1 | Create `run_lineage_summary` (1 row/run, array-based) | 30× storage reduction, simpler recursive CTE |
+| P3-2 | Migrate V1 recursive CTE to use new schema | Query simplification |
+| P3-3 | Implement partition detach/archive job | 2-year retention enforcement |
+| P3-4 | Add `job_denormalized.namespace_name` column | V2 correctness |
+| P3-5 | Make AGE writes async | V3 write latency |
+
+### Phase 4 — Long-term (Month 2+, API parity)
+
+| # | Change |
+|---|---|
+| P4-1 | V3 `aggregateToParentRun` support |
+| P4-2 | V3 `includeFacets` support |
+| P4-3 | V3 configurable depth |
+| P4-4 | Pagination for lineage responses (cursor-based) |
+| P4-5 | Field projection (`?fields=uuid,job_name,state`) |
+| P4-6 | Async lineage API (webhook/polling) for depth > 5 |
+
+---
+
+## 9. Monitoring Queries
+
+```sql
+-- Check if any rows landed in DEFAULT partition (partition management failure)
+SELECT COUNT(*) FROM run_lineage_denormalized_default;
+
+-- Find the top write amplifiers (runs with most denorm rows)
+SELECT run_uuid, COUNT(*) AS row_count
+FROM run_lineage_denormalized
+GROUP BY run_uuid
+ORDER BY row_count DESC
+LIMIT 20;
+
+-- Long-running lineage queries (requires pg_stat_statements)
+SELECT query, calls, mean_exec_time, max_exec_time
+FROM pg_stat_statements
+WHERE query ILIKE '%run_lineage_denormalized%'
+ORDER BY max_exec_time DESC
+LIMIT 10;
+
+-- Partition sizes
+SELECT
+    c.relname AS partition,
+    pg_size_pretty(pg_total_relation_size(c.oid)) AS size,
+    pg_stat_user_tables.n_live_tup AS live_rows
+FROM pg_class c
+JOIN pg_inherits i ON i.inhrelid = c.oid
+JOIN pg_class p ON p.oid = i.inhparent
+JOIN pg_stat_user_tables ON pg_stat_user_tables.relname = c.relname
+WHERE p.relname = 'run_lineage_denormalized'
+ORDER BY c.relname;
+
+-- Upsert conflict rate (high = write churn from RUNNING events)
+SELECT n_tup_upd, n_tup_ins, n_tup_upd::float / NULLIF(n_tup_ins + n_tup_upd, 0) AS churn_ratio
+FROM pg_stat_user_tables
+WHERE relname LIKE 'run_lineage_denormalized%';
+```
+
+---
+
+## 10. Configuration Recommendations
+
+```yaml
+# config.yml — HikariCP tuning for 1M events/day write load
+database:
+  maxSize: 30                    # Default is ~10; write path needs more connections
+  minSize: 10
+  maxWaitForConnection: 5s
+  validationQuery: "SELECT 1"
+  connectionTimeout: 5000
+  idleTimeout: 600000
+  maxLifetime: 1800000
+
+# PostgreSQL postgresql.conf recommendations
+shared_buffers: 4GB              # 25% of RAM
+effective_cache_size: 12GB       # 75% of RAM
+work_mem: 64MB                   # per-sort; recursive CTEs use multiple sorts
+maintenance_work_mem: 1GB        # for VACUUM, index builds
+max_parallel_workers_per_gather: 4
+wal_buffers: 64MB
+checkpoint_completion_target: 0.9
+```
+
+---
+
+## Appendix: Spark OpenLineage Event Profile
+
+A typical Spark application on this system:
+
+```
+Event 1:  type=START,    inputs=[],           outputs=[]          ← no datasets yet
+Events 2–198: type=RUNNING, inputs=[same],   outputs=[same]      ← metric updates only
+Event 199: type=RUNNING, inputs=[10 tables], outputs=[3 tables]  ← datasets appear at stage end
+Event 200: type=COMPLETE, inputs=[10 tables], outputs=[3 tables] ← terminal
+```
+
+Only events 199 and 200 carry actionable lineage data. The current system processes all 200 identically.
+
+With Phase 1 change P1-3, events 2–198 skip the denorm write entirely. This is safe because:
+- The denorm table is populated from the normalized tables (`runs`, `runs_input_mapping`, `dataset_versions`)
+- The normalized tables are updated on every event (required for run state tracking)
+- The denorm write is a redundant cache of normalized data

--- a/docs/mesh-lineage-perf-design.md
+++ b/docs/mesh-lineage-perf-design.md
@@ -581,6 +581,15 @@ COMMIT;                                                  -- drop _old after veri
 denormalized tables; extend it to also manage these three (create next month on
 the 1st, detach + drop/archive partitions past the retention window).
 
+> **Status (V110):** lifecycle for the two composite RANGE→HASH tables shipped so
+> far (`lineage_edges`, `run_facets`) is now automated. V110 adds
+> `create_monthly_hash_partition()` and `drop_old_hash_partitions()`, and
+> `PartitionManagementJob` calls `createCompositePartitionsForPeriod` (provision
+> upcoming months, indexes auto-propagate) + `cleanupOldCompositePartitions`
+> (`DROP … CASCADE` whole months past retention: `run_facets` 12mo,
+> `lineage_edges` 24mo). `dataset_facets` / `lineage_events` follow the same
+> pattern when they are partitioned.
+
 ### 5d. Retention Policy Table
 
 ```sql
@@ -680,7 +689,8 @@ These must match V1 signature before V3 is production-ready.
 | P2-5 | Remove silent V2→V1 dataset fallback | `LineageService.java` | V2 correctness | ❌ |
 | P2-6 | Partition `run_facets` table | V108 migration | 7.3B row problem | ❌ (tracked as TODO in V107) |
 | P2-7 | Upsert only on state change (`WHERE ... IS DISTINCT FROM`) | `DenormalizedLineageService.java` | WAL reduction | ❌ |
-| P2-8 | `lineage_edges` adjacency table + write path | V107 / `DenormalizedLineageService.java` | Enables §3f BFS read path | 🟡 write done, read not wired |
+| P2-8 | `lineage_edges` adjacency table + write/read path | V107/V109 / `LineageService.java` | §3f BFS read path | ✅ write + read (run & job/dataset) wired behind `MARQUEZ_LINEAGE_USE_EDGE_BFS` |
+| P2-6 | Partition `run_facets` table | V108 migration | 7.3B row problem | ✅ |
 
 ### Phase 3 — Medium-term (Month 1, schema replacement)
 
@@ -689,7 +699,7 @@ These must match V1 signature before V3 is production-ready.
 | P3-0 | Wire `lineage_edges` BFS-in-Java read path behind a flag (§3f) | Index-accelerated reads, replaces recursive CTE | ❌ |
 | P3-1 | Create `run_lineage_summary` (1 row/run, array-based + GIN) | 30× storage reduction, single-arm OR CTE (§2c) | ❌ |
 | P3-2 | Migrate V1 recursive CTE to use new schema | Query simplification | ❌ |
-| P3-3 | Implement partition detach/archive job | 2-year retention enforcement | ❌ |
+| P3-3 | Implement partition detach/archive job | 2-year retention enforcement | 🟡 V110: create + drop-by-retention automated for `lineage_edges`/`run_facets` (composite tables); `dataset_facets`/`lineage_events` pending |
 | P3-4 | Add `job_denormalized.namespace_name` column | V2 correctness | ❌ |
 | P3-5 | Make AGE writes async | V3 write latency | ❌ |
 

--- a/docs/mesh-lineage-perf-design.md
+++ b/docs/mesh-lineage-perf-design.md
@@ -531,27 +531,48 @@ CREATE TABLE run_parent_lineage_denormalized_default
 
 Alert when rows land in the DEFAULT partition — it means the partition creation job failed.
 
-### 5c. Normalized Table Retention
+### 5c. Large Raw-Table Retention (the 2-year problem)
 
-The `lineage_events`, `runs`, `run_facets`, `dataset_versions`, and `run_states` tables are NOT partitioned. At 1M events/day × 730 days:
+**Verified against the live schema (V107):** only the *denormalized* tables are
+partitioned. Every large *raw* table is plain and — importantly — **none of the
+big facet/event tables has a PRIMARY KEY or UNIQUE constraint**, so they can be
+RANGE-partitioned with no need to fold the partition key into a unique index.
 
-| Table | Rows at 2 years |
-|---|---|
-| lineage_events | ~730M |
-| runs | ~3.65M (5,000/day) |
-| run_states | ~14.6M (4 states/run) |
-| run_facets | ~7.3B (at 10 facets/event × 200 events) |
-| dataset_versions | ~7.3M |
+| Table | Partitioned? | Unique constraint? | Partition key (verified col) | Rows at 2yr (1M events/day) | Retention |
+|---|:---:|:---:|---|---|---|
+| `run_facets` | ❌ | none | `lineage_event_time` | ~7.3B (~1.1 TB) | 12 months |
+| `dataset_facets` | ❌ | none | `lineage_event_time` | ~0.7–3.6B | 12 months |
+| `lineage_events` | ❌ | none | `event_time` (or `run_date`) | ~730M, large JSONB → TBs | 24 months |
+| `job_facets` | ❌ | none | `lineage_event_time` | ~3.6M | 24 months |
+| `column_lineage` | ❌ | none | `created_at` | schema-dependent | 24 months |
+| `run_states` | ❌ | — | (small) | ~14.6M | keep |
+| `runs`, `dataset_versions` | ❌ | — | (small) | ~3.6M / ~7.3M | keep |
 
-**`run_facets` is the critical one**: at 10 facets/event × 1M events/day = 10M rows/day → **7.3 billion rows** over 2 years. This must be partitioned.
+The three critical tables are **`run_facets`, `dataset_facets`, `lineage_events`** —
+together they dominate storage. Each gets the same treatment: RANGE partition by
+its event-time column, one partition per month, plus a `DEFAULT` safety-net
+partition (validated working on PostgreSQL: `LIKE … PARTITION BY RANGE` routes
+rows to the correct monthly partition).
 
 ```sql
--- V106: Partition run_facets by lineage_event_time
--- (requires data migration — do as background job)
-CREATE TABLE run_facets_partitioned (
-    LIKE run_facets INCLUDING ALL
-) PARTITION BY RANGE (lineage_event_time);
+-- V108 (per table; run_facets shown). Tables are populated, so partition via a
+-- shadow table + copy + swap inside a maintenance window. For FRESH installs,
+-- create the table partitioned from the start (no copy needed).
+CREATE TABLE run_facets_p (LIKE run_facets INCLUDING DEFAULTS INCLUDING INDEXES)
+    PARTITION BY RANGE (lineage_event_time);
+-- monthly partitions 2024-01 … current+1, created by PartitionManagementService
+CREATE TABLE run_facets_p_default PARTITION OF run_facets_p DEFAULT;
+-- copy in batches by month, then swap:
+INSERT INTO run_facets_p SELECT * FROM run_facets;     -- batched in production
+BEGIN;
+  ALTER TABLE run_facets        RENAME TO run_facets_old;
+  ALTER TABLE run_facets_p      RENAME TO run_facets;
+COMMIT;                                                  -- drop _old after verify
 ```
+
+`PartitionManagementService` already creates monthly partitions for the
+denormalized tables; extend it to also manage these three (create next month on
+the 1st, detach + drop/archive partitions past the retention window).
 
 ### 5d. Retention Policy Table
 

--- a/docs/mesh-lineage-perf-design.md
+++ b/docs/mesh-lineage-perf-design.md
@@ -699,7 +699,7 @@ These must match V1 signature before V3 is production-ready.
 | P3-0 | Wire `lineage_edges` BFS-in-Java read path behind a flag (§3f) | Index-accelerated reads, replaces recursive CTE | ❌ |
 | P3-1 | Create `run_lineage_summary` (1 row/run, array-based + GIN) | 30× storage reduction, single-arm OR CTE (§2c) | ❌ |
 | P3-2 | Migrate V1 recursive CTE to use new schema | Query simplification | ❌ |
-| P3-3 | Implement partition detach/archive job | 2-year retention enforcement | 🟡 V110: create + drop-by-retention automated for `lineage_edges`/`run_facets` (composite tables); `dataset_facets`/`lineage_events` pending |
+| P3-3 | Implement partition detach/archive job | 2-year retention enforcement | ✅ V110/V112: create + drop-by-retention automated for all composite tables (`lineage_edges`, `run_facets`, `dataset_facets`, `lineage_events`) |
 | P3-4 | Add `job_denormalized.namespace_name` column | V2 correctness | ❌ |
 | P3-5 | Make AGE writes async | V3 write latency | ❌ |
 

--- a/marquez_data_model.md
+++ b/marquez_data_model.md
@@ -1,6 +1,6 @@
 # Marquez Data Model
 
-> **Last updated:** 2026-06-30 — verified against Flyway migration **V108** (`partition_run_facets`).
+> **Last updated:** 2026-06-30 — verified against Flyway migration **V109** (`add_job_dataset_lineage_edges`).
 > This document is maintained by the Technical Writer agent. After any Flyway migration, run
 > `bmad/agents/technical-writer-agent.md` → "Audit Migration" to update this file.
 
@@ -374,7 +374,7 @@ Same structure as `run_lineage_denormalized`. RANGE partitioned by `run_date`.
 > `runs.parent_run_uuid` / `runs_input_mapping.run_uuid` / `dataset_versions.run_uuid`
 > lookups.
 
-### `lineage_edges` (V107)
+### `lineage_edges` (V107; job↔dataset edges added in V109)
 **Partition strategy:** composite RANGE(`run_date`, monthly) → HASH(`namespace`, 8)
 + hash-subpartitioned `DEFAULT` (same convention as the denormalized tables:
 RANGE-by-date like `run_lineage_denormalized`, HASH-by-namespace like
@@ -382,34 +382,48 @@ RANGE-by-date like `run_lineage_denormalized`, HASH-by-namespace like
 month); the namespace hash gives per-tenant physical isolation so one high-volume
 namespace cannot bloat another's storage/IO/vacuum.
 
-Pre-materialized run↔dataset_version adjacency for BFS-style lineage reads
-(an alternative to the recursive CTE). One row per hop. Written at COMPLETE/FAIL/
-ABORT time by `DenormalizedLineageService.populateLineageEdgesForRun` and
-back-filled from `runs_input_mapping` / `dataset_versions` by V107.
+Pre-materialized adjacency for BFS-style lineage reads (an alternative to the
+recursive CTE). Stores **two edge families** in one table — the node-id spaces are
+disjoint so they never collide:
+- **run ↔ dataset_version** (run / dataset-version lineage): one row per hop,
+  `run_uuid` set. Written at COMPLETE/FAIL/ABORT by
+  `DenormalizedLineageService.populateLineageEdgesForRun`, back-filled from
+  `runs_input_mapping` / `dataset_versions` by V107.
+- **job ↔ dataset** (job / dataset lineage, **V109**): `dataset --CONSUMES--> job`
+  (input) and `job --PRODUCES--> dataset` (output), `run_uuid` NULL. A BFS over
+  these reproduces the job-lineage adjacency (two jobs are connected when they
+  share ANY dataset). Written alongside run edges by
+  `populateLineageEdgesForRun`; back-filled from current `job_versions_io_mapping`
+  by V109 (`run_date` = the job version's `made_current_at`).
 
 | Column | Type |
 |--------|------|
 | `from_node_id` | UUID NOT NULL (part of PK) |
-| `from_type` | TEXT NOT NULL — `dataset_version` \| `run` \| `job` |
+| `from_type` | TEXT NOT NULL — `dataset_version` \| `run` \| `dataset` \| `job` |
 | `to_node_id` | UUID NOT NULL (part of PK) |
 | `to_type` | TEXT NOT NULL |
 | `edge_type` | TEXT NOT NULL — `PRODUCES` \| `CONSUMES` (part of PK) |
-| `namespace` | TEXT NOT NULL — namespace (tenant) of the run endpoint (HASH key, part of PK) |
-| `run_uuid` | UUID NOT NULL — run endpoint of the edge |
+| `namespace` | TEXT NOT NULL — namespace (tenant) of the run/job endpoint (HASH key, part of PK) |
+| `run_uuid` | UUID **NULL** — run endpoint of run edges; NULL for job↔dataset edges (V109 relaxed NOT NULL) |
 | `run_date` | DATE NOT NULL — RANGE partition key (part of PK) |
 | `created_at` | TIMESTAMPTZ NOT NULL DEFAULT NOW() |
 
 PK `(from_node_id, to_node_id, edge_type, run_date, namespace)` — `run_date` and
-`namespace` are functionally determined by the run endpoint, so including them in
-the key does not change physical-edge dedup. Parent indexes
+`namespace` are functionally determined by the run/job endpoint, so including them
+in the key does not change physical-edge dedup. Parent indexes
 `idx_lineage_edges_downstream (from_node_id, to_type, run_date DESC)` and
 `idx_lineage_edges_upstream (to_node_id, from_type, run_date DESC)` propagate to
 every partition.
 
-> **Read note:** a BFS lookup keyed only on `from_node_id`/`to_node_id` scans all
-> partitions; passing a `run_date` range (e.g. the UI's time window) prunes to one
-> month's hash buckets. `lineage_edges` is currently write-only, so this applies
-> only once the BFS read path replaces the recursive CTE (follow-up).
+> **Read note:** the BFS read path is wired behind the `MARQUEZ_LINEAGE_USE_EDGE_BFS`
+> flag (default OFF) in `LineageService` — run/dataset-version lineage via
+> `traverseRunLineageEdges`, job/dataset lineage via `traverseJobLineageEdges` —
+> hydrating the visited set with the existing queries so the emitted graph matches
+> the recursive-CTE path. A lookup keyed only on `from_node_id`/`to_node_id` scans
+> all partitions; passing a `run_date` range (e.g. the UI's time window) prunes to
+> one month's hash buckets. Run-edge BFS passes the run date range; job-edge BFS is
+> not date-bounded (job edges are dated by `made_current_at`) so it scans across
+> months and relies on the namespace hash + indexes.
 
 ### `run_facets` (partitioned in V108)
 **Partition strategy:** composite RANGE(`lineage_event_time`, monthly) →

--- a/marquez_data_model.md
+++ b/marquez_data_model.md
@@ -1,6 +1,6 @@
 # Marquez Data Model
 
-> **Last updated:** 2026-06-30 — verified against Flyway migration **V109** (`add_job_dataset_lineage_edges`).
+> **Last updated:** 2026-06-30 — verified against Flyway migration **V110** (`composite_partition_management_functions`).
 > This document is maintained by the Technical Writer agent. After any Flyway migration, run
 > `bmad/agents/technical-writer-agent.md` → "Audit Migration" to update this file.
 
@@ -451,8 +451,35 @@ disabled) are dropped, not recreated. `run_facets` has no PRIMARY KEY (INSERT-on
 > `getParentRunLineageWithFacets`) pass the seed runs' `lineage_event_time` range
 > (the same `:minDate`/`:maxDate` they already bind), pruning ~104 → ~8 partitions.
 
-> **V109/V110 (planned):** `dataset_facets` and `lineage_events` get the same
+> **Follow-up (planned):** `dataset_facets` and `lineage_events` get the same
 > composite scheme (`lineage_events` already has `job_namespace`).
+
+### Partition lifecycle for the composite tables (V110)
+
+The pre-existing `create_monthly_partition()` / `drop_old_partitions()` helpers
+only understand the single-level denormalized tables (flat RANGE + denorm-specific
+indexes). V110 adds two helpers for the composite RANGE→HASH tables
+(`lineage_edges`, `run_facets`):
+
+- **`create_monthly_hash_partition(parent_table, partition_prefix, start_date, hash_modulus)`**
+  — creates one monthly RANGE partition that is itself HASH(`namespace`)-subpartitioned
+  into `hash_modulus` buckets. No index DDL: Postgres propagates the parent's
+  partitioned indexes to every new partition automatically (verified — function-created
+  partitions carry the same indexes as the V107/V108 ones). Advisory-locked +
+  exception-guarded for concurrent/idempotent runs. `partition_prefix` is passed
+  separately because `run_facets`' partitions keep the shadow `_p` prefix
+  (`run_facets_p_y2026m01`) after V108's rename swap.
+- **`drop_old_hash_partitions(parent_table, retention_months)`** — discovers monthly
+  partitions via `pg_inherits` (prefix-agnostic; the DEFAULT partition has no
+  `y####m##` suffix and is skipped) and `DROP … CASCADE`s any month older than the
+  retention window, removing its hash sub-partitions with it.
+
+`PartitionManagementJob` (runs at startup, then every `frequencyDays`) calls
+`createCompositePartitionsForPeriod` to provision upcoming months and
+`cleanupOldCompositePartitions` to enforce retention. Retention per the design doc:
+**`run_facets` 12 months, `lineage_edges` 24 months** (hash modulus 8). These run
+only at runtime — never from the historical Flyway migrations (V86 etc.) that
+predate the tables and helpers.
 
 ### `dataset_denormalized`
 **Partition strategy:** HASH by `namespace_uuid` (8 partitions)

--- a/marquez_data_model.md
+++ b/marquez_data_model.md
@@ -1,6 +1,6 @@
 # Marquez Data Model
 
-> **Last updated:** 2026-06-29 — verified against Flyway migration **V107** (`create_lineage_edges_and_partition_run_facets`).
+> **Last updated:** 2026-06-30 — verified against Flyway migration **V108** (`partition_run_facets`).
 > This document is maintained by the Technical Writer agent. After any Flyway migration, run
 > `bmad/agents/technical-writer-agent.md` → "Audit Migration" to update this file.
 
@@ -411,10 +411,34 @@ every partition.
 > month's hash buckets. `lineage_edges` is currently write-only, so this applies
 > only once the BFS read path replaces the recursive CTE (follow-up).
 
-> **V108 (planned):** `run_facets` (~7.3B rows/2yr), `dataset_facets`, and
-> `lineage_events` get the same composite RANGE(event_date)→HASH(namespace)
-> scheme via shadow-table + swap; `run_facets`/`dataset_facets` gain a `namespace`
-> column (`lineage_events` already has `job_namespace`).
+### `run_facets` (partitioned in V108)
+**Partition strategy:** composite RANGE(`lineage_event_time`, monthly) →
+HASH(`namespace`, 8) + hash-subpartitioned `DEFAULT` — the top storage table
+(~7.3B rows / ~1.1 TB over 2 years at 1M events/day). V108 adds a `namespace`
+column (denormalized from `runs.namespace_name` via `run_uuid`; NULL when
+`run_uuid` is NULL) and migrates the populated table via shadow-table + copy +
+atomic rename swap, re-adding the `run_facets_run_uuid_fkey` FK (→`runs` ON DELETE
+CASCADE) and the trivial `run_facets_view`. The dead matviews `run_lineage_view`
+and `run_parent_lineage_view` (replaced by `run_lineage_denormalized`; refresher
+disabled) are dropped, not recreated. `run_facets` has no PRIMARY KEY (INSERT-only).
+
+| Column | Type |
+|--------|------|
+| `created_at` | TIMESTAMPTZ NOT NULL |
+| `run_uuid` | UUID (FK → runs, nullable) |
+| `lineage_event_time` | TIMESTAMPTZ NOT NULL — RANGE partition key |
+| `lineage_event_type` | VARCHAR NOT NULL |
+| `name` | VARCHAR NOT NULL |
+| `facet` | JSONB NOT NULL |
+| `namespace` | TEXT — HASH key; the run's `namespace_name` (tenant) |
+
+> **Read note:** facet lookups are keyed on `run_uuid`; to prune the partitions,
+> the lineage facet joins (`getRunLineageWithFacets` /
+> `getParentRunLineageWithFacets`) pass the seed runs' `lineage_event_time` range
+> (the same `:minDate`/`:maxDate` they already bind), pruning ~104 → ~8 partitions.
+
+> **V109/V110 (planned):** `dataset_facets` and `lineage_events` get the same
+> composite scheme (`lineage_events` already has `job_namespace`).
 
 ### `dataset_denormalized`
 **Partition strategy:** HASH by `namespace_uuid` (8 partitions)

--- a/marquez_data_model.md
+++ b/marquez_data_model.md
@@ -375,11 +375,17 @@ Same structure as `run_lineage_denormalized`. RANGE partitioned by `run_date`.
 > lookups.
 
 ### `lineage_edges` (V107)
+**Partition strategy:** composite RANGE(`run_date`, monthly) → HASH(`namespace`, 8)
++ hash-subpartitioned `DEFAULT` (same convention as the denormalized tables:
+RANGE-by-date like `run_lineage_denormalized`, HASH-by-namespace like
+`dataset_denormalized`). Monthly partitions give O(1) retention (DROP an old
+month); the namespace hash gives per-tenant physical isolation so one high-volume
+namespace cannot bloat another's storage/IO/vacuum.
+
 Pre-materialized run↔dataset_version adjacency for BFS-style lineage reads
 (an alternative to the recursive CTE). One row per hop. Written at COMPLETE/FAIL/
 ABORT time by `DenormalizedLineageService.populateLineageEdgesForRun` and
-back-filled from `runs_input_mapping` / `dataset_versions` by V107. **Not
-partitioned** (PK must be globally unique on the physical edge).
+back-filled from `runs_input_mapping` / `dataset_versions` by V107.
 
 | Column | Type |
 |--------|------|
@@ -388,17 +394,27 @@ partitioned** (PK must be globally unique on the physical edge).
 | `to_node_id` | UUID NOT NULL (part of PK) |
 | `to_type` | TEXT NOT NULL |
 | `edge_type` | TEXT NOT NULL — `PRODUCES` \| `CONSUMES` (part of PK) |
+| `namespace` | TEXT NOT NULL — namespace (tenant) of the run endpoint (HASH key, part of PK) |
 | `run_uuid` | UUID NOT NULL — run endpoint of the edge |
-| `run_date` | DATE NOT NULL |
+| `run_date` | DATE NOT NULL — RANGE partition key (part of PK) |
 | `created_at` | TIMESTAMPTZ NOT NULL DEFAULT NOW() |
 
-PK `(from_node_id, to_node_id, edge_type)`; indexes `idx_lineage_edges_downstream`
-`(from_node_id, to_type, run_date DESC)` and `idx_lineage_edges_upstream`
-`(to_node_id, from_type, run_date DESC)` for bidirectional traversal.
+PK `(from_node_id, to_node_id, edge_type, run_date, namespace)` — `run_date` and
+`namespace` are functionally determined by the run endpoint, so including them in
+the key does not change physical-edge dedup. Parent indexes
+`idx_lineage_edges_downstream (from_node_id, to_type, run_date DESC)` and
+`idx_lineage_edges_upstream (to_node_id, from_type, run_date DESC)` propagate to
+every partition.
 
-> **V107 PART 2 (advisory):** `run_facets` reaches ~7.3B rows over 2 years at
-> 1M events/day and must be RANGE-partitioned by `lineage_event_time`; tracked as
-> a follow-up (V108) requiring a maintenance window.
+> **Read note:** a BFS lookup keyed only on `from_node_id`/`to_node_id` scans all
+> partitions; passing a `run_date` range (e.g. the UI's time window) prunes to one
+> month's hash buckets. `lineage_edges` is currently write-only, so this applies
+> only once the BFS read path replaces the recursive CTE (follow-up).
+
+> **V108 (planned):** `run_facets` (~7.3B rows/2yr), `dataset_facets`, and
+> `lineage_events` get the same composite RANGE(event_date)→HASH(namespace)
+> scheme via shadow-table + swap; `run_facets`/`dataset_facets` gain a `namespace`
+> column (`lineage_events` already has `job_namespace`).
 
 ### `dataset_denormalized`
 **Partition strategy:** HASH by `namespace_uuid` (8 partitions)

--- a/marquez_data_model.md
+++ b/marquez_data_model.md
@@ -1,6 +1,6 @@
 # Marquez Data Model
 
-> **Last updated:** 2026-06-30 — verified against Flyway migration **V110** (`composite_partition_management_functions`).
+> **Last updated:** 2026-06-30 — verified against Flyway migration **V111** (`partition_dataset_facets`).
 > This document is maintained by the Technical Writer agent. After any Flyway migration, run
 > `bmad/agents/technical-writer-agent.md` → "Audit Migration" to update this file.
 
@@ -466,8 +466,23 @@ interrupted copy loses nothing.
 > `getParentRunLineageWithFacets`) pass the seed runs' `lineage_event_time` range
 > (the same `:minDate`/`:maxDate` they already bind), pruning ~104 → ~8 partitions.
 
-> **Follow-up (planned):** `dataset_facets` and `lineage_events` get the same
-> composite scheme (`lineage_events` already has `job_namespace`).
+### `dataset_facets` (partitioned in V111, online cutover)
+Same composite RANGE(`lineage_event_time`) → HASH(`namespace`, 8) scheme and the
+**identical size-branched online cutover** as `run_facets` (inline swap ≤ 1 GiB;
+large tables arm a dual-write trigger + `DATASET_FACETS_PARTITION_V1` background
+copy + count-verified swap). Differences from `run_facets`: three FKs
+(`dataset_uuid`→datasets, `dataset_version_uuid`→dataset_versions,
+`run_uuid`→runs), all restored at swap; dependent `dataset_facets_view` recreated;
+`namespace` denormalized from the run's `namespace_name`. INSERT-only, no PK.
+
+Both cutover jobs share `AbstractPartitionCutoverBackfillJob` (ctid-keyset copy +
+verified swap); each subclass supplies only its table-specific column list, FK/view
+DDL, and marker/trigger names.
+
+> **Follow-up (planned):** `lineage_events` gets the same composite scheme
+> (`lineage_events` already has `job_namespace`), with extra care for its
+> actively-refreshed matview `lineage_events_by_type_hourly_view` and nullable
+> `created_at`.
 
 ### Partition lifecycle for the composite tables (V110)
 

--- a/marquez_data_model.md
+++ b/marquez_data_model.md
@@ -1,6 +1,6 @@
 # Marquez Data Model
 
-> **Last updated:** 2026-06-28 — verified against Flyway migration **V105** (`add_index_for_latest_run_lookup`).
+> **Last updated:** 2026-06-29 — verified against Flyway migration **V107** (`create_lineage_edges_and_partition_run_facets`).
 > This document is maintained by the Technical Writer agent. After any Flyway migration, run
 > `bmad/agents/technical-writer-agent.md` → "Audit Migration" to update this file.
 
@@ -367,6 +367,38 @@ These tables are maintained asynchronously by background jobs (backfill checkpoi
 
 ### `run_parent_lineage_denormalized`
 Same structure as `run_lineage_denormalized`. RANGE partitioned by `run_date`.
+
+> **V106** added safety-net `DEFAULT` partitions to both `run_lineage_denormalized`
+> and `run_parent_lineage_denormalized` (catch rows whose `run_date` has no monthly
+> partition), plus covering indexes for the recursive-CTE traversal join and the
+> `runs.parent_run_uuid` / `runs_input_mapping.run_uuid` / `dataset_versions.run_uuid`
+> lookups.
+
+### `lineage_edges` (V107)
+Pre-materialized run↔dataset_version adjacency for BFS-style lineage reads
+(an alternative to the recursive CTE). One row per hop. Written at COMPLETE/FAIL/
+ABORT time by `DenormalizedLineageService.populateLineageEdgesForRun` and
+back-filled from `runs_input_mapping` / `dataset_versions` by V107. **Not
+partitioned** (PK must be globally unique on the physical edge).
+
+| Column | Type |
+|--------|------|
+| `from_node_id` | UUID NOT NULL (part of PK) |
+| `from_type` | TEXT NOT NULL — `dataset_version` \| `run` \| `job` |
+| `to_node_id` | UUID NOT NULL (part of PK) |
+| `to_type` | TEXT NOT NULL |
+| `edge_type` | TEXT NOT NULL — `PRODUCES` \| `CONSUMES` (part of PK) |
+| `run_uuid` | UUID NOT NULL — run endpoint of the edge |
+| `run_date` | DATE NOT NULL |
+| `created_at` | TIMESTAMPTZ NOT NULL DEFAULT NOW() |
+
+PK `(from_node_id, to_node_id, edge_type)`; indexes `idx_lineage_edges_downstream`
+`(from_node_id, to_type, run_date DESC)` and `idx_lineage_edges_upstream`
+`(to_node_id, from_type, run_date DESC)` for bidirectional traversal.
+
+> **V107 PART 2 (advisory):** `run_facets` reaches ~7.3B rows over 2 years at
+> 1M events/day and must be RANGE-partitioned by `lineage_event_time`; tracked as
+> a follow-up (V108) requiring a maintenance window.
 
 ### `dataset_denormalized`
 **Partition strategy:** HASH by `namespace_uuid` (8 partitions)

--- a/marquez_data_model.md
+++ b/marquez_data_model.md
@@ -425,16 +425,31 @@ every partition.
 > not date-bounded (job edges are dated by `made_current_at`) so it scans across
 > months and relies on the namespace hash + indexes.
 
-### `run_facets` (partitioned in V108)
+### `run_facets` (partitioned in V108, online cutover)
 **Partition strategy:** composite RANGE(`lineage_event_time`, monthly) →
 HASH(`namespace`, 8) + hash-subpartitioned `DEFAULT` — the top storage table
 (~7.3B rows / ~1.1 TB over 2 years at 1M events/day). V108 adds a `namespace`
 column (denormalized from `runs.namespace_name` via `run_uuid`; NULL when
-`run_uuid` is NULL) and migrates the populated table via shadow-table + copy +
-atomic rename swap, re-adding the `run_facets_run_uuid_fkey` FK (→`runs` ON DELETE
-CASCADE) and the trivial `run_facets_view`. The dead matviews `run_lineage_view`
-and `run_parent_lineage_view` (replaced by `run_lineage_denormalized`; refresher
-disabled) are dropped, not recreated. `run_facets` has no PRIMARY KEY (INSERT-only).
+`run_uuid` is NULL) and builds the empty partitioned shadow. `run_facets` has no
+PRIMARY KEY (INSERT-only). The dead matviews `run_lineage_view` /
+`run_parent_lineage_view` (replaced by `run_lineage_denormalized`; refresher
+disabled) are dropped, not recreated.
+
+**Size-branched, online cutover** (V108 does not block startup):
+- **Small / empty (≤ 1 GiB — fresh installs, CI):** copy + atomic rename swap
+  **inline** in the migration (instant on an empty table), re-adding the
+  `run_facets_run_uuid_fkey` FK (→`runs` ON DELETE CASCADE) and `run_facets_view`.
+  Marker `run_facets_partition_state.state = 'SWAPPED'`.
+- **Large (> 1 GiB — production):** the migration only arms an **online cutover** —
+  an `AFTER INSERT` trigger mirrors every row with `created_at >= cutover` into the
+  shadow (dual-write), and records `cutover` + `state = 'DUAL_WRITE'`. The heavy
+  historical copy (`created_at < cutover`) and the swap are deferred to the
+  `RUN_FACETS_PARTITION_V1` backfill job (see below), off the startup path.
+
+The `created_at < cutover` / `>= cutover` split is disjoint by value, so the copy
+and the trigger each own every row exactly once — no primary key needed. The old
+table stays the source of truth until a count-verified atomic swap, so an
+interrupted copy loses nothing.
 
 | Column | Type |
 |--------|------|

--- a/marquez_data_model.md
+++ b/marquez_data_model.md
@@ -1,6 +1,6 @@
 # Marquez Data Model
 
-> **Last updated:** 2026-06-30 — verified against Flyway migration **V111** (`partition_dataset_facets`).
+> **Last updated:** 2026-06-30 — verified against Flyway migration **V112** (`partition_lineage_events`).
 > This document is maintained by the Technical Writer agent. After any Flyway migration, run
 > `bmad/agents/technical-writer-agent.md` → "Audit Migration" to update this file.
 
@@ -479,10 +479,27 @@ Both cutover jobs share `AbstractPartitionCutoverBackfillJob` (ctid-keyset copy 
 verified swap); each subclass supplies only its table-specific column list, FK/view
 DDL, and marker/trigger names.
 
-> **Follow-up (planned):** `lineage_events` gets the same composite scheme
-> (`lineage_events` already has `job_namespace`), with extra care for its
-> actively-refreshed matview `lineage_events_by_type_hourly_view` and nullable
-> `created_at`.
+### `lineage_events` (partitioned in V112, online cutover)
+Same online cutover, RANGE(`event_time`) → **HASH(`job_namespace`, 8)** — it uses
+the existing `job_namespace` column, so no new column is added. Two differences
+handled by the shared base:
+- **Nullable boundary:** `created_at` (DEFAULT `now()`) is the cutover boundary,
+  but rows predating that column may be NULL. The backfill's `copyBoundaryPredicate`
+  is `created_at < :cutover OR created_at IS NULL`, so NULLs are copied as history
+  (new rows always get the default, so they're never NULL and stay on the trigger's
+  side — disjoint).
+- **Actively-refreshed matview:** `lineage_events_by_type_hourly_view` is dropped
+  before the rename and recreated `WITH NO DATA` after (instant, short lock), then
+  repopulated by the job's `afterSwapCommitted()` hook (`REFRESH MATERIALIZED
+  VIEW`). No FKs, so nothing else to restore.
+
+**V112 also generalizes** `create_monthly_hash_partition(parent, prefix, date,
+modulus, hash_column)` (V110's version hardcoded `HASH (namespace)`); the runtime
+lifecycle now passes each table's hash column (`namespace` for the facet/edge
+tables, `job_namespace` for `lineage_events`). `lineage_events` retention: 24 months.
+
+All three large facet/event tables (`run_facets`, `dataset_facets`,
+`lineage_events`) now use the same `AbstractPartitionCutoverBackfillJob`.
 
 ### Partition lifecycle for the composite tables (V110)
 


### PR DESCRIPTION
This pull request makes significant improvements to the lineage graph queries and denormalized lineage processing in the backend, focusing on correctness, deduplication, and performance. The main changes include splitting lineage traversal into explicit upstream and downstream arms for more accurate graph construction, deduplicating dataset version aggregations, introducing pre-materialized lineage edges for faster BFS queries, and enforcing depth limits to prevent runaway queries.

**Lineage query and traversal improvements:**

* Refactored recursive lineage queries to separate upstream and downstream traversals, ensuring that each direction is handled explicitly and preventing cycles by avoiding self-joins. This change applies to both `lineage` and `lineage_graph` CTEs as well as their parent variants. [[1]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eR298) [[2]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eL308-R328) [[3]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eR400) [[4]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eL382-R430) [[5]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eR545) [[6]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eL499-R575) [[7]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eR643-R662) [[8]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eL578-R673)

* Improved aggregation of input and output dataset versions by deduplicating on dataset version UUIDs using subqueries instead of relying on `JSON_AGG(DISTINCT ...)`. This ensures each dataset version appears only once per run in the output. [[1]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eL328-R364) [[2]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eL405-R469)

**Performance and correctness enhancements:**

* Added a new routine to pre-materialize lineage edges into a `lineage_edges` table, with `ON CONFLICT DO NOTHING` to avoid duplicates. This enables efficient BFS traversal in Java and ensures each physical edge is only written once. [[1]](diffhunk://#diff-22ca22e92422f1fd51ccf1c021118e3340963f0c08e00862ed0d1b44a7881303R539-R543) [[2]](diffhunk://#diff-22ca22e92422f1fd51ccf1c021118e3340963f0c08e00862ed0d1b44a7881303R694-R756)

* Introduced hard-coded server-side depth caps for lineage queries (`MAX_DEPTH_V1 = 10`, `MAX_DEPTH_V2 = 20`), and enforced them in both V1 and V2 lineage endpoints to prevent runaway recursive CTEs and unbounded responses. [[1]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1R67-R71) [[2]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1R89) [[3]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1R208-R211)

**Other fixes and logging improvements:**

* Fixed a bug in a dataset version facet join by ensuring the correct run UUID is referenced.
* Improved logging for dataset version lookups and run lineage construction, and added a warning when V2 denormalized tables lag behind. [[1]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1L256-R266) [[2]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1L537-R547)

### Problem

👋 Thanks for opening a [pull request](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#submitting-a-pull-request)! Please include a brief summary of the problem your change is trying to solve, or bug fix. If your change fixes a bug or you'd like to provide context on why you're making the change, please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) as follows:

Closes: #ISSUE-NUMBER

### Solution

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a database schema migration, please describe the schema modification(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
